### PR TITLE
Use new shell command instead of `os.system` in examples

### DIFF
--- a/examples/tests/test_cli.py
+++ b/examples/tests/test_cli.py
@@ -2,7 +2,10 @@
 Tests for command line interface (CLI)
 """
 import pytest
+
 from cli_test_helpers import shell
+from importlib.metadata import version
+from os import linesep
 
 import foobar.cli
 
@@ -20,6 +23,17 @@ def test_entrypoint():
     Is entrypoint script installed? (setup.py)
     """
     result = shell('foobar --help')
+    assert result.status == 0
+
+
+def test_version():
+    """
+    Does --version display information as expected?
+    """
+    expected_version = version('foobar')
+    result = shell('foobar --version')
+
+    assert result.stdout == f"foobar, version {expected_version}{linesep}"
     assert result.status == 0
 
 

--- a/examples/tests/test_cli.py
+++ b/examples/tests/test_cli.py
@@ -1,8 +1,8 @@
 """
 Tests for command line interface (CLI)
 """
-import os
 import pytest
+from cli_test_helpers import shell
 
 import foobar.cli
 
@@ -11,24 +11,24 @@ def test_runas_module():
     """
     Can this package be run as a Python module?
     """
-    exit_status = os.system('python -m foobar --help')
-    assert exit_status == 0
+    result = shell('python -m foobar --help')
+    assert result.status == 0
 
 
 def test_entrypoint():
     """
     Is entrypoint script installed? (setup.py)
     """
-    exit_status = os.system('foobar --help')
-    assert exit_status == 0
+    result = shell('foobar --help')
+    assert result.status == 0
 
 
 def test_baz_command():
     """
     Is command available?
     """
-    exit_status = os.system('foobar baz --help')
-    assert exit_status == 0
+    result = shell('foobar baz --help')
+    assert result.status == 0
 
 
 # NOTE:


### PR DESCRIPTION
The new `shell` command that we provide offers a few nice features that we can show off with our example test setup.