### PR TITLE
Use `exit_code` instead of `status` to align with Click framework

### DIFF
--- a/cli_test_helpers/__init__.py
+++ b/cli_test_helpers/__init__.py
@@ -5,7 +5,7 @@ __author__ = 'Peter Bittner'
 __email__ = 'peter@painless.software'
 __license__ = 'GPLv3'
 __url__ = 'https://github.com/painless-software/python-cli-test-helpers'
-__version__ = '2.0.0'
+__version__ = '2.1.0'
 
 __all__ = [
     'ArgvContext',

--- a/cli_test_helpers/commands.py
+++ b/cli_test_helpers/commands.py
@@ -34,7 +34,7 @@ def shell(command, **kwargs):
         completed = run(command, shell=True, capture_output=True, **kwargs)
 
     return Namespace(
-        status=completed.returncode,
+        exit_code=completed.returncode,
         stdout=completed.stdout.decode(),
         stderr=completed.stderr.decode(),
     )

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -24,7 +24,7 @@ Start with a simple set of functional tests:
 - Is command XYZ available? etc. Cover your entire CLI usage here!
 
 This is almost a stupid exercise: Run the command as a shell command
-and inspect the status code of the exiting process (see |example (test-cli)|_).
+and inspect the exit code of the exiting process (see |example (test-cli)|_).
 
 The trick is that you run a non-destructive command, e.g. by using the usual
 ``--help`` option of every command. This should cover your entire CLI user

--- a/examples/tests/test_cli.py
+++ b/examples/tests/test_cli.py
@@ -15,7 +15,7 @@ def test_runas_module():
     Can this package be run as a Python module?
     """
     result = shell('python -m foobar --help')
-    assert result.status == 0
+    assert result.exit_code == 0
 
 
 def test_entrypoint():
@@ -23,7 +23,7 @@ def test_entrypoint():
     Is entrypoint script installed? (setup.py)
     """
     result = shell('foobar --help')
-    assert result.status == 0
+    assert result.exit_code == 0
 
 
 def test_version():
@@ -34,7 +34,7 @@ def test_version():
     result = shell('foobar --version')
 
     assert result.stdout == f"foobar, version {expected_version}{linesep}"
-    assert result.status == 0
+    assert result.exit_code == 0
 
 
 def test_baz_command():
@@ -42,7 +42,7 @@ def test_baz_command():
     Is command available?
     """
     result = shell('foobar baz --help')
-    assert result.status == 0
+    assert result.exit_code == 0
 
 
 # NOTE:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -14,15 +14,15 @@ def test_shell_output():
 
     result = shell("echo " + message)
 
-    assert result.status == 0, "Command execution reported as failure"
+    assert result.exit_code == 0, "Command execution reported as failure"
     assert result.stdout == message + linesep, "Unexpected output of shell"
 
 
 def test_shell_fails_gracefully():
     """
     An erroneous command execution throws no exception but sets the exit
-    status to nonzero.
+    code to nonzero.
     """
     result = shell("some-invalid-command-that-doesnt-exist")
 
-    assert result.status != 0, "Command execution not reported as failure"
+    assert result.exit_code != 0, "Command execution not reported as failure"


### PR DESCRIPTION
The wording for [exit status](https://en.wikipedia.org/wiki/Exit_status) is a debated topic, but why make it difficult for our audience? The Click framework [uses `exit_code`](https://click.palletsprojects.com/en/8.0.x/testing/?highlight=exit_code), and it makes sense to align with them.