### PR TITLE
Add pyproject.toml, run coverage with unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,6 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
-*.so
-
 # Distribution / packaging
 .Python
 build/
@@ -46,40 +43,18 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+tests/*-report.json
+tests/*-report.xml
 
 # Translations
 *.mo
 *.pot
 
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
 # Sphinx documentation
 docs/_build/
 
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
 # pyenv
 .python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
-*.sage.py
 
 # Environments
 .env
@@ -89,13 +64,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
 
 # mkdocs documentation
 /site

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.bandit]
+# NOTE: Exclude/ignore of files is currently broken in Bandit
+exclude = [".git",".github",".tox","tests"]
+skips = ["B404","B602"]
+
+[tool.black]
+color = true
+
+[tool.coverage.xml]
+output = "tests/coverage-report.xml"
+
+[tool.isort]
+color_output = true
+profile = "black"
+
+[tool.pylint.master]
+disable = ["super-with-arguments"]
+output-format = "colorized"
+
+[tool.pytest.ini_options]
+addopts = "--junitxml=tests/unittests-report.xml --doctest-modules --ignore examples/ --color=yes --verbose"

--- a/tox.ini
+++ b/tox.ini
@@ -29,22 +29,25 @@ description = Unit tests
 deps =
     py34: typing
     py3{9,10}: setuptools>=50
+    coverage[toml]
     pytest
 commands =
-    pytest {posargs:tests}
+    coverage run --source cli_test_helpers -m pytest {posargs:tests}
+    coverage xml
+    coverage report
 
 [testenv:bandit]
 description = PyCQA security linter
-deps = bandit<1.6.0
-commands = bandit -r . --ini tox.ini
+deps = bandit
+commands = bandit -r {posargs:cli_test_helpers} -s B404,B602
 
 [testenv:clean]
 description = Remove bytecode and other debris
 deps = pyclean
 commands =
     pyclean {toxinidir}
-    rm -rf .tox build dist docs/_build cli_test_helpers.egg-info examples/.tox examples/foobar.egg-info
-whitelist_externals =
+    rm -rf .coverage .tox build dist docs/_build cli_test_helpers.egg-info examples/.tox examples/foobar.egg-info tests/coverage-report.xml test/unittests-report.xml
+allowlist_externals =
     rm
 
 [testenv:docs]
@@ -61,14 +64,14 @@ commands =
     sed -i 's#cli-test-helpers#../../python-cli-test-helpers#' tox.ini
     tox -e py38
     sed -i 's#../../python-cli-test-helpers#cli-test-helpers#' tox.ini
-whitelist_externals =
+allowlist_externals =
     sed
     tox
 
 [testenv:flake8]
 description = Static code analysis and code style
 deps = flake8
-commands = flake8
+commands = flake8 {posargs}
 
 [testenv:isort]
 description = Ensure imports are ordered consistently
@@ -78,7 +81,7 @@ commands = isort --check-only --diff {posargs:cli_test_helpers setup tests examp
 [testenv:pylint]
 description = Check for errors and code smells
 deps = pylint
-commands = pylint cli_test_helpers setup
+commands = pylint {posargs:cli_test_helpers setup}
 
 [testenv:readme]
 description = Ensure README renders on PyPI
@@ -86,10 +89,6 @@ deps = twine
 commands =
     {envpython} setup.py -q sdist bdist_wheel
     twine check dist/*
-
-[bandit]
-exclude = .tox,build,dist,tests
-skips = B404,B602
 
 [flake8]
 exclude = .tox,build,dist,cli_test_helpers.egg-info


### PR DESCRIPTION
Moves most test and linting tool configuration settings to the new popular [pyproject.toml](https://discuss.python.org/t/where-to-get-started-with-pyproject-toml/4906) file, thus cleaning up `tox.ini`.

In addition, we generate coverage information when running unit tests for more transparency.