### PR TITLE
Speed up linting tasks, enable colors, modernize

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+env:
+  PY_COLORS: "1"
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,8 +24,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install prerequisites
-      run: python -m pip install --upgrade setuptools pip tox
+      run: python -m pip install tox --disable-pip-version-check
     - name: Run ${{ matrix.env }}
       run: tox -e ${{ matrix.env }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
     - "*"
 
+env:
+  PY_COLORS: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,11 +12,11 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install prerequisites
-      run: python -m pip install --upgrade pip setuptools twine wheel
+      run: python -m pip install build twine wheel --disable-pip-version-check
     - name: Build package
-      run: python setup.py sdist bdist_wheel
+      run: python -m build
     - name: Upload to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+env:
+  PY_COLORS: "1"
+
 jobs:
   test:
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install prerequisites
-      run: python -m pip install --upgrade setuptools pip wheel tox-gh-actions
+      run: python -m pip install tox-gh-actions wheel --disable-pip-version-check
     - name: Run tests
       run: tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ skips = ["B404","B602"]
 [tool.black]
 color = true
 
+[tool.coverage.run]
+source = ["cli_test_helpers"]
+
 [tool.coverage.xml]
 output = "tests/coverage-report.xml"
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,17 +31,19 @@ deps =
     coverage[toml]
     pytest
 commands =
-    coverage run --source cli_test_helpers -m pytest {posargs:tests}
+    coverage run -m pytest {posargs:tests}
     coverage xml
     coverage report
 
 [testenv:bandit]
 description = PyCQA security linter
+skip_install = true
 deps = bandit
 commands = bandit -r {posargs:cli_test_helpers} -s B404,B602
 
 [testenv:clean]
 description = Remove bytecode and other debris
+skip_install = true
 deps = pyclean
 commands =
     pyclean {toxinidir}
@@ -53,6 +55,7 @@ allowlist_externals =
 
 [testenv:docs]
 description = Build package documentation (HTML)
+skip_install = true
 deps = sphinx
 changedir = docs
 commands = make html
@@ -60,6 +63,7 @@ allowlist_externals = make
 
 [testenv:examples]
 description = Run tests for examples
+skip_install = true
 changedir = {toxinidir}/examples/
 commands =
     sed -i 's#cli-test-helpers#../../python-cli-test-helpers#' tox.ini
@@ -71,11 +75,13 @@ allowlist_externals =
 
 [testenv:flake8]
 description = Static code analysis and code style
+skip_install = true
 deps = flake8
 commands = flake8 {posargs}
 
 [testenv:isort]
 description = Ensure imports are ordered consistently
+skip_install = true
 deps = isort[colors]
 commands = isort --check-only --diff {posargs:cli_test_helpers setup tests examples}
 
@@ -86,9 +92,12 @@ commands = pylint {posargs:cli_test_helpers setup}
 
 [testenv:readme]
 description = Ensure README renders on PyPI
-deps = twine
+skip_install = true
+deps =
+    build
+    twine
 commands =
-    {envpython} setup.py -q sdist bdist_wheel
+    python -m build
     twine check dist/*
 
 [flake8]


### PR DESCRIPTION
By default, Tox installs the application under development in every virtual environment. This is not needed to make the linting jobs work, hence we can save time.

On GHA, we should be able to rely on the build images to contain a recently up-to-date Pip, hence we can spare upgrading the tool, and disabling the warning instead should be a safe-enough choice.