### PR TITLE
Activate isort, test-drive generation of docs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         env:
         - flake8
+        - isort
         - pylint
         - bandit
         - readme

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,8 +22,9 @@ jobs:
         - isort
         - pylint
         - bandit
-        - readme
         - examples
+        - readme
+        - docs
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/cli_test_helpers/decorators.py
+++ b/cli_test_helpers/decorators.py
@@ -3,6 +3,7 @@ Useful helpers for writing tests for your CLI tool
 """
 
 import sys
+
 try:
     from unittest.mock import patch
 except ImportError:  # Python 2.7

--- a/examples/setup.py
+++ b/examples/setup.py
@@ -3,9 +3,8 @@ Packaging for example CLI tool
 """
 from pathlib import Path
 
-from setuptools import find_packages, setup
-
 import foobar as package
+from setuptools import find_packages, setup
 
 
 def read_file(filename):

--- a/examples/tests/test_cli.py
+++ b/examples/tests/test_cli.py
@@ -4,10 +4,10 @@ Tests for command line interface (CLI)
 from importlib.metadata import version
 from os import linesep
 
-import pytest
-from cli_test_helpers import shell
-
 import foobar.cli
+import pytest
+
+from cli_test_helpers import shell
 
 
 def test_runas_module():

--- a/examples/tests/test_command.py
+++ b/examples/tests/test_command.py
@@ -3,10 +3,10 @@ Tests for the command module
 """
 from unittest.mock import patch
 
-import pytest
-from cli_test_helpers import ArgvContext, EnvironContext
-
 import foobar.command
+import pytest
+
+from cli_test_helpers import ArgvContext, EnvironContext
 
 
 @patch('foobar.command.example')

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ Packaging setup for cli-test-helpers
 """
 
 from os.path import abspath, dirname, join
+
 from setuptools import find_packages, setup
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@
 [tox]
 envlist =
     flake8
+    isort
     pylint
     bandit
     py{27,35,36,37,38,39,310,py2,py3}
@@ -83,7 +84,7 @@ commands = flake8 {posargs}
 description = Ensure imports are ordered consistently
 skip_install = true
 deps = isort[colors]
-commands = isort --check-only --diff {posargs:cli_test_helpers setup tests examples}
+commands = isort --check-only --diff {posargs:cli_test_helpers setup.py tests examples}
 
 [testenv:pylint]
 description = Check for errors and code smells


### PR DESCRIPTION
It went unnoticed that [isort](https://pycqa.github.io/isort/) was not executed as a CI job yet.

It also makes sense to test-drive the generation of the docs with every PR.