### PR TITLE
Make file argument mandatory (docopt example)

### DIFF
--- a/examples/docopt/foobar/cli.py
+++ b/examples/docopt/foobar/cli.py
@@ -4,11 +4,11 @@ An example CLI program.
 
 Usage:
   foobar (-h | --help | --version)
-  foobar [-s | --silent] FILE
-  foobar [-v | --verbose] FILE
+  foobar [-s | --silent] <file>
+  foobar [-v | --verbose] <file>
 
 Positional arguments:
-  FILE           target file path name
+  file           target file path name
 
 Optional arguments:
   -h, --help     show this help message and exit
@@ -29,7 +29,7 @@ def parse_arguments():
     args = docopt(__doc__, version=__version__)
 
     return dict(
-        file=args['FILE'],
+        file=args['<file>'],
         silent=args['-s'] or args['--silent'],
         verbose=args['-v'] or args['--verbose'],
     )

--- a/examples/docopt/tests/test_cli.py
+++ b/examples/docopt/tests/test_cli.py
@@ -45,6 +45,20 @@ def test_file_argument():
     assert result.exit_code == 0
 
 
+def test_mandatory_arguments():
+    """
+    Is the `file` parameter mandatory?
+    """
+    result = shell('foobar')
+    assert result.exit_code != 0, result.stdout
+
+
+# NOTE:
+# You can continue here, adding all CLI action and option combinations
+# using a non-destructive option, such as --help, to test for the
+# availability of the CLI command or option.
+
+
 @pytest.mark.parametrize('option,silent,verbose', [
     ('-s', True, False),
     ('-v', False, True),
@@ -61,18 +75,3 @@ def test_options(option, silent, verbose):
     assert args['file'] == 'myfile'
     assert args['silent'] == silent
     assert args['verbose'] == verbose
-
-
-# NOTE:
-# You can continue here, adding all CLI action and option combinations
-# using a non-destructive option, such as --help, to test for the
-# availability of the CLI command or option.
-
-
-def test_cli():
-    """
-    Does CLI stop execution w/o a command argument?
-    """
-    with pytest.raises(SystemExit):
-        foobar.cli.main()
-        pytest.fail("CLI doesn't abort asking for a command argument")

--- a/examples/docopt/tests/test_command.py
+++ b/examples/docopt/tests/test_command.py
@@ -17,11 +17,11 @@ def test_process_is_called(mock_command):
         foobar.cli.main()
 
     assert mock_command.called
-    assert mock_command.call_args.kwargs == {
-        'file': 'myfile',
-        'silent': False,
-        'verbose': True,
-    }
+    assert mock_command.call_args.kwargs == dict(
+        file='myfile',
+        silent=False,
+        verbose=True,
+    )
 
 
 @patch('foobar.command.print')


### PR DESCRIPTION
Copy+paste from the output of an `argparse`-based CLI implementation uses CAPITAL letters instead of the `<file>` syntax for mandatory positional arguments.

This went unnoticed even with the tests. Not nice. We fix the syntax now.