### PR TITLE
Exercise code in `__main__` module (examples)

### DIFF
--- a/examples/argparse/tests/test_cli.py
+++ b/examples/argparse/tests/test_cli.py
@@ -1,6 +1,7 @@
 """
 Tests for command line interface (CLI)
 """
+from importlib import import_module
 from importlib.metadata import version
 from os import linesep
 
@@ -8,6 +9,13 @@ import {{module}}.cli
 import pytest
 
 from cli_test_helpers import ArgvContext, shell
+
+
+def test_main_module():
+    """
+    Exercise (most of) the code in the ``__main__`` module.
+    """
+    import_module('{{module}}.__main__')
 
 
 def test_runas_module():

--- a/examples/click/tests/test_cli.py
+++ b/examples/click/tests/test_cli.py
@@ -1,6 +1,7 @@
 """
 Tests for command line interface (CLI)
 """
+from importlib import import_module
 from importlib.metadata import version
 from os import linesep
 
@@ -8,6 +9,13 @@ import {{module}}.cli
 from click.testing import CliRunner
 
 from cli_test_helpers import shell
+
+
+def test_main_module():
+    """
+    Exercise (most of) the code in the ``__main__`` module.
+    """
+    import_module('{{module}}.__main__')
 
 
 def test_runas_module():

--- a/examples/docopt/tests/test_cli.py
+++ b/examples/docopt/tests/test_cli.py
@@ -1,6 +1,7 @@
 """
 Tests for command line interface (CLI)
 """
+from importlib import import_module
 from importlib.metadata import version
 from os import linesep
 
@@ -8,6 +9,13 @@ import {{module}}.cli
 import pytest
 
 from cli_test_helpers import ArgvContext, shell
+
+
+def test_main_module():
+    """
+    Exercise (most of) the code in the ``__main__`` module.
+    """
+    import_module('{{module}}.__main__')
 
 
 def test_runas_module():


### PR DESCRIPTION
We can increase code coverage (in our exercises) by importing the `__main__` module in a CLI test.

The code that is guarded from being executed during an import (by `if __name__ == '__main__':`) is not executed this way. To also execute that remains an exercise to the reader, for future iterations.