### PR TITLE
Add test on CLI usage to examples, use dispatch function

### DIFF
--- a/examples/argparse/tests/test_cli.py
+++ b/examples/argparse/tests/test_cli.py
@@ -4,6 +4,7 @@ Tests for command line interface (CLI)
 from importlib import import_module
 from importlib.metadata import version
 from os import linesep
+from unittest.mock import patch
 
 import {{module}}.cli
 import pytest
@@ -32,6 +33,21 @@ def test_entrypoint():
     """
     result = shell('{{package}} --help')
     assert result.exit_code == 0
+
+
+@patch('{{module}}.cli.dispatch')
+def test_usage(mock_dispatch):
+    """
+    Does CLI abort w/o arguments, displaying usage instructions?
+    """
+    with ArgvContext('{{package}}'), pytest.raises(SystemExit):
+        {{module}}.cli.main()
+
+    assert not mock_dispatch.called, 'CLI should stop execution'
+
+    result = shell('{{package}}')
+
+    assert 'usage:' in result.stderr
 
 
 def test_version():
@@ -69,12 +85,3 @@ def test_set_action():
 # You can continue here, adding all CLI action and option combinations
 # using a non-destructive option, such as --help, to test for the
 # availability of the CLI command or option.
-
-
-def test_cli():
-    """
-    Does CLI stop execution w/o a command argument?
-    """
-    with pytest.raises(SystemExit):
-        {{module}}.cli.main()
-        pytest.fail("CLI doesn't abort asking for a command argument")

--- a/examples/argparse/{{module}}/cli.py
+++ b/examples/argparse/{{module}}/cli.py
@@ -7,9 +7,7 @@ from . import __version__, command
 
 
 def parse_arguments():
-    """
-    Parse and handle CLI arguments
-    """
+    """Parse and handle CLI arguments."""
     parser = argparse.ArgumentParser(description='{{project}}')
 
     parser.add_argument('--version', action='version', version=__version__)
@@ -21,11 +19,15 @@ def parse_arguments():
     return args
 
 
-def main():
-    """{{project}}"""
-    args = parse_arguments()
-
+def dispatch(args):
+    """Execute functionality requested through the CLI."""
     if args.action == 'get':
         command.example(args)
     else:
         raise NotImplementedError(args.action)
+
+
+def main():
+    """{{project}}."""
+    args = parse_arguments()
+    dispatch(args)

--- a/examples/click/tests/test_cli.py
+++ b/examples/click/tests/test_cli.py
@@ -34,6 +34,17 @@ def test_entrypoint():
     assert result.exit_code == 0
 
 
+def test_usage():
+    """
+    Does CLI abort w/o arguments, displaying usage instructions?
+    """
+    runner = CliRunner()
+    result = runner.invoke({{module}}.cli.main)
+
+    assert 'Usage:' in result.output
+    assert result.exit_code != 0
+
+
 def test_version():
     """
     Does --version display information as expected?
@@ -57,13 +68,3 @@ def test_example_command():
 # You can continue here, adding all CLI command combinations
 # using a non-destructive option, such as --help, to test for
 # the availability of the CLI command or option.
-
-
-def test_cli():
-    """
-    Does CLI stop execution w/o a command argument?
-    """
-    runner = CliRunner()
-    result = runner.invoke({{module}}.cli.main)
-
-    assert result.exit_code != 0

--- a/examples/docopt/tests/test_cli.py
+++ b/examples/docopt/tests/test_cli.py
@@ -4,6 +4,7 @@ Tests for command line interface (CLI)
 from importlib import import_module
 from importlib.metadata import version
 from os import linesep
+from unittest.mock import patch
 
 import {{module}}.cli
 import pytest
@@ -34,6 +35,21 @@ def test_entrypoint():
     assert result.exit_code == 0
 
 
+@patch('{{module}}.command.dispatch')
+def test_usage(mock_dispatch):
+    """
+    Does CLI abort w/o arguments, displaying usage instructions?
+    """
+    with ArgvContext('{{package}}'), pytest.raises(SystemExit):
+        {{module}}.cli.main()
+
+    assert not mock_dispatch.called, 'CLI should stop execution'
+
+    result = shell('{{package}}')
+
+    assert 'Usage:' in result.stderr
+
+
 def test_version():
     """
     Does --version display information as expected?
@@ -51,14 +67,6 @@ def test_file_argument():
     """
     result = shell('{{package}} myfile --help')
     assert result.exit_code == 0
-
-
-def test_mandatory_arguments():
-    """
-    Is the `file` parameter mandatory?
-    """
-    result = shell('{{package}}')
-    assert result.exit_code != 0, result.stdout
 
 
 # NOTE:

--- a/examples/docopt/tests/test_command.py
+++ b/examples/docopt/tests/test_command.py
@@ -8,16 +8,16 @@ import {{module}}
 from cli_test_helpers import ArgvContext
 
 
-@patch('{{module}}.command.process')
-def test_process_is_called(mock_command):
+@patch('{{module}}.command.dispatch')
+def test_dispatch_is_called(mock_dispatch):
     """
     Is the correct code called when invoked via the CLI?
     """
     with ArgvContext('{{package}}', 'myfile', '-v'):
         {{module}}.cli.main()
 
-    assert mock_command.called
-    assert mock_command.call_args.kwargs == dict(
+    assert mock_dispatch.called
+    assert mock_dispatch.call_args.kwargs == dict(
         file='myfile',
         silent=False,
         verbose=True,
@@ -26,11 +26,11 @@ def test_process_is_called(mock_command):
 
 @patch('{{module}}.command.print')
 @patch('{{module}}.command.open')
-def test_process_business_logic(mock_openfile, mock_print):
+def test_dispatch_business_logic(mock_openfile, mock_print):
     """
-    Walk the code of the process function.
+    Walk the code of the dispatch function.
     """
-    {{module}}.command.process(file='myfile', silent=False, verbose=True)
+    {{module}}.command.dispatch(file='myfile', silent=False, verbose=True)
 
     assert mock_openfile.called
     assert mock_print.call_count == 3, \

--- a/examples/docopt/{{module}}/cli.py
+++ b/examples/docopt/{{module}}/cli.py
@@ -23,9 +23,7 @@ from . import command
 
 
 def parse_arguments():
-    """
-    Parse and handle CLI arguments
-    """
+    """Parse and handle CLI arguments."""
     args = docopt(__doc__, version=__version__)
 
     return dict(
@@ -36,7 +34,6 @@ def parse_arguments():
 
 
 def main():
-    """{{project}}"""
+    """{{project}}."""
     args = parse_arguments()
-
-    command.process(**args)
+    command.dispatch(**args)

--- a/examples/docopt/{{module}}/command.py
+++ b/examples/docopt/{{module}}/command.py
@@ -1,9 +1,9 @@
 """
-Example command module
+Example command module.
 """
 
 
-def process(file, silent, verbose):
+def dispatch(file, silent, verbose):
     """An example implementation"""
 
     with open(file) as textfile:


### PR DESCRIPTION
A test that verifies that the usage instructions are printed was missing in the examples until now.

In addition, we now call the function appropriately that provides the dispatching of CLI functionality.