### PR TITLE
Update Tox configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - ubuntu-latest
+        - ubuntu-20.04
         - macos-latest
         - windows-latest
         python-version:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,9 +41,9 @@ templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 extlinks = {
-    'github': ('https://github.com/%s', ''),
-    'gitlab': ('https://gitlab.com/%s', ''),
-    'pypi': ('https://pypi.org/project/%s', ''),
+    'github': ('https://github.com/%s', None),
+    'gitlab': ('https://gitlab.com/%s', None),
+    'pypi': ('https://pypi.org/project/%s', None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -48,11 +48,7 @@ commands = bandit {posargs:-r cli_test_helpers -s B404,B602}
 description = Remove bytecode and other debris
 skip_install = true
 deps = pyclean
-commands =
-    pyclean {toxinidir}
-    rm -rf .tox build dist docs/_build cli_test_helpers.egg-info .coverage coverage.xml tests/junit-report.xml
-allowlist_externals =
-    rm
+commands = pyclean {posargs:. --debris --erase build/**/* build/ docs/_build/**/* docs/_build/ tests/junit-report.xml --yes}
 
 [testenv:docs]
 description = Build package documentation (HTML)

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
 description = PyCQA security linter
 skip_install = true
 deps = bandit
-commands = bandit {posargs:-r cli_test_helpers -s B404,B602}
+commands = bandit -s B404,B602 -r cli_test_helpers {posargs}
 
 [testenv:clean]
 description = Remove bytecode and other debris


### PR DESCRIPTION
- Makes use of pyclean's new `--debris` and `--erase` options
- Fixes a Tox evaluation problem of the posargs placeholder
- Fixes a Sphinx configuration syntax issue
- Pin Ubuntu image on Azure for older Python versions