### PR TITLE
One copier configuration file does it all

### DIFF
--- a/examples/click/copier.yaml
+++ b/examples/click/copier.yaml
@@ -1,7 +1,0 @@
-project: Click CLI Example
-package: "{{ project.lower().replace(' ', '-') }}"
-module: "{{ project.lower().replace(' ', '_') }}"
-author: Your name
-email: your.name@example.com
-url: https://example.com
-_templates_suffix: ""

--- a/examples/copier.yaml
+++ b/examples/copier.yaml
@@ -1,7 +1,14 @@
-project: Argparse CLI Example
+_subdirectory: "{{ engine.lower() }}"
+_templates_suffix: ""
+engine:
+  choices:
+  - Argparse
+  - Click
+  - Docopt
+  type: str
+project: "{{ engine }} CLI Example"
 package: "{{ project.lower().replace(' ', '-') }}"
 module: "{{ project.lower().replace(' ', '_') }}"
 author: Your name
 email: your.name@example.com
 url: https://example.com
-_templates_suffix: ""

--- a/examples/docopt/copier.yaml
+++ b/examples/docopt/copier.yaml
@@ -1,7 +1,0 @@
-project: Docopt CLI Example
-package: "{{ project.lower().replace(' ', '-') }}"
-module: "{{ project.lower().replace(' ', '_') }}"
-author: Your name
-email: your.name@example.com
-url: https://example.com
-_templates_suffix: ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.bandit]
-exclude_dirs = [".git",".github",".tox","tests"]
+exclude_dirs = [".git",".github",".tox","examples","tests"]
 skips = ["B404","B602"]
 
 [tool.black]

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ description = Run test suite of example project
 deps = copier
 skip_install = true
 commands =
-    copier {toxinidir}/examples/argparse {toxworkdir}/examples/argparse -d package='foobar' -d module='foobar' --defaults
+    copier {toxinidir}/examples {toxworkdir}/examples/argparse -d engine='Argparse' -d package='foobar' -d module='foobar' --defaults
     tox -c {toxworkdir}/examples/argparse/tox.ini -e flake8,isort
     tox -c {toxworkdir}/examples/argparse/tox.ini -e py -- -vv
 allowlist_externals =
@@ -75,7 +75,7 @@ description = Run test suite of example project
 deps = copier
 skip_install = true
 commands =
-    copier {toxinidir}/examples/click {toxworkdir}/examples/click -d package='foobar' -d module='foobar' --defaults
+    copier {toxinidir}/examples {toxworkdir}/examples/click -d engine='Click' -d package='foobar' -d module='foobar' --defaults
     tox -c {toxworkdir}/examples/click/tox.ini -e flake8,isort
     tox -c {toxworkdir}/examples/click/tox.ini -e py -- -vv
 allowlist_externals =
@@ -86,7 +86,7 @@ description = Run test suite of example project
 deps = copier
 skip_install = true
 commands =
-    copier {toxinidir}/examples/docopt {toxworkdir}/examples/docopt -d package='foobar' -d module='foobar' --defaults
+    copier {toxinidir}/examples {toxworkdir}/examples/docopt -d engine='Docopt' -d package='foobar' -d module='foobar' --defaults
     tox -c {toxworkdir}/examples/docopt/tox.ini -e flake8,isort
     tox -c {toxworkdir}/examples/docopt/tox.ini -e py -- -vv
 allowlist_externals =


### PR DESCRIPTION
The [Copier documentation](https://copier.readthedocs.io/en/stable/configuring/#subdirectory) mentions the `_subdirectory` option, which allows having a single `copier.yml` file to rule the generation of all example setups.

## Related

- Discussion: https://github.com/copier-org/copier/discussions/855