### PR TITLE
Allow to generate examples directly off GitHub

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -1,4 +1,4 @@
-_subdirectory: "{{ engine.lower() }}"
+_subdirectory: "examples/{{ engine.lower() }}"
 _templates_suffix: ""
 engine:
   choices:

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -5,10 +5,9 @@ Examples
 #. `click <click>`__ – *using the Click CLI library with TDD*
 #. `docopt <docopt>`__ – *using the docopt-ng CLI library with TDD*
 
-The examples folder is a `Copier <https://copier.readthedocs.io/>`_ template.
-You can use ``copier`` to generate a working CLI project suiting your needs,
-interactively selecting one of the CLI libraries above. Clone this repository
-and run:
+The examples in this folder are a `Copier`_ template. You can use ``copier``
+to generate a working CLI project suiting your needs, interactively selecting
+one of the CLI libraries above, e.g.
 
 .. code-block:: console
 
@@ -16,4 +15,11 @@ and run:
 
 .. code-block:: console
 
-    copier examples cli-example
+    copier gh:painless-software/python-cli-test-helpers cli-example
+
+Add the ``--vcs-ref HEAD`` option to pick all changes from the repository that
+might have been added after the latest release. See the `Copier documentation`_
+for further details on generating projects from templates.
+
+.. _Copier: https://copier.readthedocs.io/
+.. _Copier documentation: https://copier.readthedocs.io/en/stable/generating/

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ description = Run test suite of example project
 deps = copier
 skip_install = true
 commands =
-    copier {toxinidir}/examples {toxworkdir}/examples/argparse -d engine='Argparse' -d package='foobar' -d module='foobar' --defaults
+    copier {toxinidir} {toxworkdir}/examples/argparse -d engine='Argparse' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
     tox -c {toxworkdir}/examples/argparse/tox.ini -e flake8,isort
     tox -c {toxworkdir}/examples/argparse/tox.ini -e py -- -vv
 allowlist_externals =
@@ -75,7 +75,7 @@ description = Run test suite of example project
 deps = copier
 skip_install = true
 commands =
-    copier {toxinidir}/examples {toxworkdir}/examples/click -d engine='Click' -d package='foobar' -d module='foobar' --defaults
+    copier {toxinidir} {toxworkdir}/examples/click -d engine='Click' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
     tox -c {toxworkdir}/examples/click/tox.ini -e flake8,isort
     tox -c {toxworkdir}/examples/click/tox.ini -e py -- -vv
 allowlist_externals =
@@ -86,7 +86,7 @@ description = Run test suite of example project
 deps = copier
 skip_install = true
 commands =
-    copier {toxinidir}/examples {toxworkdir}/examples/docopt -d engine='Docopt' -d package='foobar' -d module='foobar' --defaults
+    copier {toxinidir} {toxworkdir}/examples/docopt -d engine='Docopt' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
     tox -c {toxworkdir}/examples/docopt/tox.ini -e flake8,isort
     tox -c {toxworkdir}/examples/docopt/tox.ini -e py -- -vv
 allowlist_externals =


### PR DESCRIPTION
We need a root-level `copier.yml` configuration file and a Git tag (or the `--vcs-ref` option) to make generating directly off GitHub work as expected.

## Related

- Follow-up on #36 