### PR TITLE
Use ruff for fast linting

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ on:
     - main
 
 env:
-  PY_COLORS: "1"
+  PY_COLORS: '1'
 
 jobs:
   check:
@@ -18,10 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
-        - flake8
-        - isort
-        - pylint
-        - bandit
+        - ruff
         - example-argparse
         - example-click
         - example-docopt
@@ -31,7 +28,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install prerequisites
       run: python -m pip install tox --disable-pip-version-check
     - name: Run ${{ matrix.env }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,10 @@ name: Publish
 on:
   push:
     tags:
-    - "*"
+    - '*'
 
 env:
-  PY_COLORS: "1"
+  PY_COLORS: '1'
 
 jobs:
   publish:
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install prerequisites
       run: python -m pip install build twine wheel --disable-pip-version-check
     - name: Build package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
     - main
 
 env:
-  PY_COLORS: "1"
+  PY_COLORS: '1'
 
 jobs:
   test:
@@ -31,7 +31,8 @@ jobs:
         - '3.10'
         - '3.11'
         - pypy-2.7
-        - pypy-3.7
+        - pypy-3.8
+        - pypy-3.9
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/README.rst
+++ b/README.rst
@@ -59,14 +59,19 @@ this:
 
 .. code-block:: shell
 
-    python3 -m pip install tox
+    python3 -m pip install tox 'virtualenv<20.22'
+
+.. note::
+
+   Virtualenv 20.22 dropped support for Python 2.7 and <3.6, which most
+   notably makes Tox fail to detect the PyPy2 executable.
 
 .. code-block:: shell
 
-    tox -lv               # list available environments
-    tox -e flake8,py310   # run a few environments
-    tox -e py             # run tests with default Python
-    tox                   # run entire suite
+    tox -lv             # list available environments
+    tox -e ruff,py311   # run a few environments
+    tox -e py           # run tests with local default Python
+    tox                 # run entire suite
 
 The included example projects can be tested independently with their dedicated
 environments, e.g.

--- a/examples/argparse/pyproject.toml
+++ b/examples/argparse/pyproject.toml
@@ -12,6 +12,7 @@ addopts = "--color=yes --doctest-modules --verbose"
 
 [tool.ruff]
 extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
+extend-ignore = ["B904"]
 
 [tool.ruff.per-file-ignores]
 "tests/*.py" = ["S101"]

--- a/examples/argparse/pyproject.toml
+++ b/examples/argparse/pyproject.toml
@@ -7,12 +7,11 @@ source = ["{{module}}"]
 [tool.coverage.report]
 show_missing = true
 
-[tool.isort]
-color_output = true
-profile = "black"
-
-[tool.pylint.master]
-output-format = "colorized"
-
 [tool.pytest.ini_options]
 addopts = "--color=yes --doctest-modules --verbose"
+
+[tool.ruff]
+extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
+
+[tool.ruff.per-file-ignores]
+"tests/*.py" = ["S101"]

--- a/examples/argparse/tests/test_command.py
+++ b/examples/argparse/tests/test_command.py
@@ -26,7 +26,7 @@ def test_fail_without_secret():
     """
     message_regex = "Environment value SECRET not set."
 
-    with ArgvContext('{{package}}', 'get'), EnvironContext(SECRET=None):
-        with pytest.raises(SystemExit, match=message_regex):
-            {{module}}.cli.main()
-            pytest.fail("CLI doesn't abort with missing SECRET")
+    with ArgvContext('{{package}}', 'get'), EnvironContext(SECRET=None), pytest.raises(
+        SystemExit, match=message_regex,
+    ):
+        {{module}}.cli.main()

--- a/examples/argparse/tox.ini
+++ b/examples/argparse/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    flake8
-    isort
+    ruff
     py3{8,9,10,11}
     package
 
@@ -9,8 +8,8 @@ envlist =
 description = Unit tests
 deps =
     cli-test-helpers
-    py3{9,10,11}: setuptools>=50
     coverage[toml]
+    py3{9,10,11}: setuptools>=50
     pytest
 commands =
     coverage run -m pytest {posargs}
@@ -20,20 +19,12 @@ commands =
 [testenv:clean]
 description = Remove bytecode and other debris
 skip_install = true
-deps = pyclean
-commands = pyclean {posargs:. --debris}
-
-[testenv:flake8]
-description = Static code analysis and code style
-skip_install = true
-deps = flake8
-commands = flake8 {posargs}
-
-[testenv:isort]
-description = Ensure imports are ordered consistently
-skip_install = true
-deps = isort[colors]
-commands = isort {posargs:--check-only --diff {{module}} setup.py tests}
+deps =
+    pyclean
+    ruff
+commands =
+    pyclean {posargs:. --debris}
+    ruff clean
 
 [testenv:package]
 description = Build package and check metadata (or upload package)
@@ -49,5 +40,8 @@ passenv =
     TWINE_PASSWORD
     TWINE_REPOSITORY_URL
 
-[flake8]
-exclude = .tox,build,dist,{{module}}.egg-info
+[testenv:ruff]
+description = Lightening-fast linting for Python
+skip_install = true
+deps = ruff
+commands = ruff {posargs:. --show-source}

--- a/examples/argparse/{{module}}/cli.py
+++ b/examples/argparse/{{module}}/cli.py
@@ -15,8 +15,7 @@ def parse_arguments():
     parser.add_argument('envvar', nargs='?', default='SECRET',
                         help='default: %(default)s')
 
-    args = parser.parse_args()
-    return args
+    return parser.parse_args()
 
 
 def dispatch(args):

--- a/examples/argparse/{{module}}/command.py
+++ b/examples/argparse/{{module}}/command.py
@@ -10,4 +10,5 @@ def example(args):
         value = os.environ[args.envvar]
         print(f'{args.envvar} = {value}')
     except KeyError:
-        raise SystemExit(f'Environment value {args.envvar} not set.')
+        msg = f'Environment value {args.envvar} not set.'
+        raise SystemExit(msg)

--- a/examples/click/pyproject.toml
+++ b/examples/click/pyproject.toml
@@ -12,6 +12,7 @@ addopts = "--color=yes --doctest-modules --verbose"
 
 [tool.ruff]
 extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
+extend-ignore = ["B904"]
 
 [tool.ruff.per-file-ignores]
 "tests/*.py" = ["S101"]

--- a/examples/click/pyproject.toml
+++ b/examples/click/pyproject.toml
@@ -7,12 +7,11 @@ source = ["{{module}}"]
 [tool.coverage.report]
 show_missing = true
 
-[tool.isort]
-color_output = true
-profile = "black"
-
-[tool.pylint.master]
-output-format = "colorized"
-
 [tool.pytest.ini_options]
 addopts = "--color=yes --doctest-modules --verbose"
+
+[tool.ruff]
+extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
+
+[tool.ruff.per-file-ignores]
+"tests/*.py" = ["S101"]

--- a/examples/click/tests/test_cli.py
+++ b/examples/click/tests/test_cli.py
@@ -6,9 +6,9 @@ from importlib.metadata import version
 from os import linesep
 
 from cli_test_helpers import shell
+from click.testing import CliRunner
 
 import {{module}}.cli
-from click.testing import CliRunner
 
 
 def test_main_module():

--- a/examples/click/tests/test_command.py
+++ b/examples/click/tests/test_command.py
@@ -26,7 +26,5 @@ def test_fail_without_secret():
     """
     message_regex = "Environment value SECRET not set."
 
-    with EnvironContext(SECRET=None):
-        with pytest.raises(SystemExit, match=message_regex):
-            {{module}}.command.example('SECRET')
-            pytest.fail("CLI doesn't abort with missing SECRET")
+    with EnvironContext(SECRET=None), pytest.raises(SystemExit, match=message_regex):
+        {{module}}.command.example('SECRET')

--- a/examples/click/tox.ini
+++ b/examples/click/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    flake8
-    isort
+    ruff
     py3{8,9,10,11}
     requirements
     package
@@ -10,8 +9,8 @@ envlist =
 description = Unit tests
 deps =
     cli-test-helpers
-    py3{9,10,11}: setuptools>=50
     coverage[toml]
+    py3{9,10,11}: setuptools>=50
     pytest
 commands =
     coverage run -m pytest {posargs}
@@ -21,20 +20,12 @@ commands =
 [testenv:clean]
 description = Remove bytecode and other debris
 skip_install = true
-deps = pyclean
-commands = pyclean {posargs:. --debris}
-
-[testenv:flake8]
-description = Static code analysis and code style
-skip_install = true
-deps = flake8
-commands = flake8 {posargs}
-
-[testenv:isort]
-description = Ensure imports are ordered consistently
-skip_install = true
-deps = isort[colors]
-commands = isort {posargs:--check-only --diff {{module}} setup.py tests}
+deps =
+    pyclean
+    ruff
+commands =
+    pyclean {posargs:. --debris}
+    ruff clean
 
 [testenv:package]
 description = Build package and check metadata (or upload package)
@@ -60,5 +51,8 @@ commands =
 allowlist_externals =
     git
 
-[flake8]
-exclude = .tox,build,dist,{{module}}.egg-info
+[testenv:ruff]
+description = Lightening-fast linting for Python
+skip_install = true
+deps = ruff
+commands = ruff {posargs:. --show-source}

--- a/examples/click/{{module}}/command.py
+++ b/examples/click/{{module}}/command.py
@@ -10,4 +10,5 @@ def example(envvar):
         value = os.environ[envvar]
         print(f'{envvar} = {value}')
     except KeyError:
-        raise SystemExit(f'Environment value {envvar} not set.')
+        msg = f'Environment value {envvar} not set.'
+        raise SystemExit(msg)

--- a/examples/docopt/pyproject.toml
+++ b/examples/docopt/pyproject.toml
@@ -12,6 +12,7 @@ addopts = "--color=yes --doctest-modules --verbose"
 
 [tool.ruff]
 extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
+extend-ignore = ["B904"]
 
 [tool.ruff.per-file-ignores]
 "tests/*.py" = ["S101"]

--- a/examples/docopt/pyproject.toml
+++ b/examples/docopt/pyproject.toml
@@ -7,12 +7,11 @@ source = ["{{module}}"]
 [tool.coverage.report]
 show_missing = true
 
-[tool.isort]
-color_output = true
-profile = "black"
-
-[tool.pylint.master]
-output-format = "colorized"
-
 [tool.pytest.ini_options]
 addopts = "--color=yes --doctest-modules --verbose"
+
+[tool.ruff]
+extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
+
+[tool.ruff.per-file-ignores]
+"tests/*.py" = ["S101"]

--- a/examples/docopt/tests/test_cli.py
+++ b/examples/docopt/tests/test_cli.py
@@ -75,7 +75,7 @@ def test_file_argument():
 # availability of the CLI command or option.
 
 
-@pytest.mark.parametrize('option,silent,verbose', [
+@pytest.mark.parametrize(('option', 'silent', 'verbose'), [
     ('-s', True, False),
     ('-v', False, True),
     ('--silent', True, False),

--- a/examples/docopt/tests/test_command.py
+++ b/examples/docopt/tests/test_command.py
@@ -17,21 +17,23 @@ def test_dispatch_is_called(mock_dispatch):
         {{module}}.cli.main()
 
     assert mock_dispatch.called
-    assert mock_dispatch.call_args.kwargs == dict(
-        file='myfile',
-        silent=False,
-        verbose=True,
-    )
+    assert mock_dispatch.call_args.kwargs == {
+        'file': 'myfile',
+        'silent': False,
+        'verbose': True,
+    }
 
 
 @patch('{{module}}.command.print')
-@patch('{{module}}.command.open')
+@patch('{{module}}.command.Path.open')
 def test_dispatch_business_logic(mock_openfile, mock_print):
     """
     Walk the code of the dispatch function.
     """
+    expected_print_calls = 3
+
     {{module}}.command.dispatch(file='myfile', silent=False, verbose=True)
 
     assert mock_openfile.called
-    assert mock_print.call_count == 3, \
+    assert mock_print.call_count == expected_print_calls, \
         "Expected 2x for --verbose, 1x for not --silent"

--- a/examples/docopt/tox.ini
+++ b/examples/docopt/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    flake8
-    isort
+    ruff
     py3{8,9,10,11}
     requirements
     package
@@ -10,8 +9,8 @@ envlist =
 description = Unit tests
 deps =
     cli-test-helpers
-    py3{9,10,11}: setuptools>=50
     coverage[toml]
+    py3{9,10,11}: setuptools>=50
     pytest
 commands =
     coverage run -m pytest {posargs}
@@ -21,20 +20,12 @@ commands =
 [testenv:clean]
 description = Remove bytecode and other debris
 skip_install = true
-deps = pyclean
-commands = pyclean {posargs:. --debris}
-
-[testenv:flake8]
-description = Static code analysis and code style
-skip_install = true
-deps = flake8
-commands = flake8 {posargs}
-
-[testenv:isort]
-description = Ensure imports are ordered consistently
-skip_install = true
-deps = isort[colors]
-commands = isort {posargs:--check-only --diff {{module}} setup.py tests}
+deps =
+    pyclean
+    ruff
+commands =
+    pyclean {posargs:. --debris}
+    ruff clean
 
 [testenv:package]
 description = Build package and check metadata (or upload package)
@@ -60,5 +51,8 @@ commands =
 allowlist_externals =
     git
 
-[flake8]
-exclude = .tox,build,dist,{{module}}.egg-info
+[testenv:ruff]
+description = Lightening-fast linting for Python
+skip_install = true
+deps = ruff
+commands = ruff {posargs:. --show-source}

--- a/examples/docopt/{{module}}/cli.py
+++ b/examples/docopt/{{module}}/cli.py
@@ -25,11 +25,11 @@ def parse_arguments():
     """Parse and handle CLI arguments."""
     args = docopt(__doc__, version=__version__)
 
-    return dict(
-        file=args['<file>'],
-        silent=args['--silent'],
-        verbose=args['--verbose'],
-    )
+    return {
+        "file": args['<file>'],
+        "silent": args['--silent'],
+        "verbose": args['--verbose'],
+    }
 
 
 def main():

--- a/examples/docopt/{{module}}/command.py
+++ b/examples/docopt/{{module}}/command.py
@@ -1,20 +1,23 @@
 """
 Example command module.
 """
+from pathlib import Path
 
 
 def dispatch(file, silent, verbose):
     """An example implementation"""
+    try:
+        with Path(file).open() as textfile:
 
-    with open(file) as textfile:
+            if verbose:
+                print("Opening text file for reading...")
 
-        if verbose:
-            print("Opening text file for reading...")
+            content = textfile.read()
 
-        content = textfile.read()
+            if verbose:
+                print("Displaying text file...")
 
-        if verbose:
-            print("Displaying text file...")
-
-        if not silent:
-            print(content)
+            if not silent:
+                print(content)
+    except FileNotFoundError as err:
+        raise SystemExit(err)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,12 @@ output-format = "colorized"
 
 [tool.pytest.ini_options]
 addopts = "--color=yes --doctest-modules --ignore examples/ --junitxml=tests/junit-report.xml --verbose"
+
+[tool.ruff]
+extend-exclude = ["examples"]
+extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
+
+[tool.ruff.per-file-ignores]
+"cli_test_helpers/commands.py" = ["S602"]
+"setup.py" = ["PTH"]
+"tests/*.py" = ["S101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ addopts = "--color=yes --doctest-modules --ignore examples/ --junitxml=tests/jun
 [tool.ruff]
 extend-exclude = ["examples"]
 extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
+extend-ignore = ["SIM105"]  # Python 2.7 only
 
 [tool.ruff.per-file-ignores]
 "cli_test_helpers/commands.py" = ["S602"]

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,11 @@
 
 [tox]
 envlist =
-    flake8
-    isort
-    pylint
-    bandit
+    ruff
     py2{7}
+    pypy2{7}
     py3{5,6,7,8,9,10,11}
-    pypy{2,3}
+    pypy3{8}
     example-{argparse,click,docopt}
     package
     docs
@@ -25,8 +23,8 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
-    pypy-2.7: pypy2
-    pypy-3.7: pypy3
+    pypy-2.7: pypy27
+    pypy-3.8: pypy38
 
 [testenv]
 description = Unit tests
@@ -39,17 +37,15 @@ commands =
     coverage xml
     coverage report
 
-[testenv:bandit]
-description = PyCQA security linter
-skip_install = true
-deps = bandit[toml]
-commands = bandit {posargs:-c pyproject.toml -r .}
-
 [testenv:clean]
 description = Remove bytecode and other debris
 skip_install = true
-deps = pyclean
-commands = pyclean {posargs:. --debris --erase build/**/* build/ docs/_build/**/* docs/_build/ tests/junit-report.xml --yes}
+deps =
+    pyclean
+    ruff
+commands =
+    pyclean {posargs:. --debris --erase build/**/* build/ docs/_build/**/* docs/_build/ tests/junit-report.xml --yes --verbose}
+    ruff clean
 
 [testenv:docs]
 description = Build package documentation (HTML)
@@ -65,7 +61,7 @@ deps = copier
 skip_install = true
 commands =
     copier {toxinidir} {toxworkdir}/examples/argparse -d engine='Argparse' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
-    tox -c {toxworkdir}/examples/argparse/tox.ini -e flake8,isort
+    tox -c {toxworkdir}/examples/argparse/tox.ini -e ruff
     tox -c {toxworkdir}/examples/argparse/tox.ini -e py -- -vv
 allowlist_externals =
     tox
@@ -76,7 +72,7 @@ deps = copier
 skip_install = true
 commands =
     copier {toxinidir} {toxworkdir}/examples/click -d engine='Click' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
-    tox -c {toxworkdir}/examples/click/tox.ini -e flake8,isort
+    tox -c {toxworkdir}/examples/click/tox.ini -e ruff
     tox -c {toxworkdir}/examples/click/tox.ini -e py -- -vv
 allowlist_externals =
     tox
@@ -87,22 +83,10 @@ deps = copier
 skip_install = true
 commands =
     copier {toxinidir} {toxworkdir}/examples/docopt -d engine='Docopt' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
-    tox -c {toxworkdir}/examples/docopt/tox.ini -e flake8,isort
+    tox -c {toxworkdir}/examples/docopt/tox.ini -e ruff
     tox -c {toxworkdir}/examples/docopt/tox.ini -e py -- -vv
 allowlist_externals =
     tox
-
-[testenv:flake8]
-description = Static code analysis and code style
-skip_install = true
-deps = flake8
-commands = flake8 {posargs}
-
-[testenv:isort]
-description = Ensure imports are ordered consistently
-skip_install = true
-deps = isort[colors]
-commands = isort {posargs:--check-only --diff cli_test_helpers setup.py tests examples/argparse examples/click examples/docopt}
 
 [testenv:package]
 description = Build package and check metadata (or upload package)
@@ -118,14 +102,11 @@ passenv =
     TWINE_PASSWORD
     TWINE_REPOSITORY_URL
 
-[testenv:pylint]
-description = Check for errors and code smells
-deps = pylint
-commands = pylint {posargs:cli_test_helpers setup}
-
-[flake8]
-exclude = .tox,build,dist,cli_test_helpers.egg-info,examples
-max-line-length = 88
+[testenv:ruff]
+description = Lightening-fast linting for Python
+skip_install = true
+deps = ruff
+commands = ruff {posargs:. --show-source}
 
 [pytest]
 addopts =


### PR DESCRIPTION
Replaces the use of several linters (Flake8, isort, Pylint, Bandit) by a single tool.