### PR TITLE
Move git tag == version check to `tox.ini`

### DIFF
--- a/examples/argparse/.gitlab-ci.yml
+++ b/examples/argparse/.gitlab-ci.yml
@@ -62,16 +62,7 @@ pypi-local:
     TWINE_PASSWORD: ${CI_JOB_TOKEN}
     TWINE_REPOSITORY_URL: ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/pypi
   script:
-  - |
-    tox -e package exec --quiet -- python -c '
-    from importlib.metadata import version
-    from os import environ
-    ver = version("{{package}}")
-    tag = environ.get("GIT_TAG") or ""
-    error = f"`{ver}` != `{tag}`"
-    abort = f"Package version does not match the Git tag ({error}). ABORTING."
-    raise SystemExit(0 if ver and tag and ver == tag else abort)
-    '
+  - tox -e ensure_version_matches -- ${GIT_TAG}
   - tox -e package -- upload
   only:
   - tags

--- a/examples/argparse/tox.ini
+++ b/examples/argparse/tox.ini
@@ -25,6 +25,11 @@ commands =
     pyclean {posargs:. --debris --erase junit-report.xml --yes}
     ruff clean
 
+[testenv:ensure_version_matches]
+description = Verify application version is same as Git tag
+deps =
+commands = python -c 'from importlib.metadata import version; ver = version("{{package}}"); tag = "'{posargs}'"; error = f"`{ver}` != `{tag}`"; abort = f"Package version does not match the Git tag ({error}). ABORTING."; raise SystemExit(0 if ver and tag and ver == tag else abort)'
+
 [testenv:package]
 description = Build package and check metadata (or upload package)
 skip_install = true

--- a/examples/click/.gitlab-ci.yml
+++ b/examples/click/.gitlab-ci.yml
@@ -69,16 +69,7 @@ pypi-local:
     TWINE_PASSWORD: ${CI_JOB_TOKEN}
     TWINE_REPOSITORY_URL: ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/pypi
   script:
-  - |
-    tox -e package exec --quiet -- python -c '
-    from importlib.metadata import version
-    from os import environ
-    ver = version("{{package}}")
-    tag = environ.get("GIT_TAG") or ""
-    error = f"`{ver}` != `{tag}`"
-    abort = f"Package version does not match the Git tag ({error}). ABORTING."
-    raise SystemExit(0 if ver and tag and ver == tag else abort)
-    '
+  - tox -e ensure_version_matches -- ${GIT_TAG}
   - tox -e package -- upload
   only:
   - tags

--- a/examples/click/tox.ini
+++ b/examples/click/tox.ini
@@ -26,6 +26,11 @@ commands =
     pyclean {posargs:. --debris --erase junit-report.xml --yes}
     ruff clean
 
+[testenv:ensure_version_matches]
+description = Verify application version is same as Git tag
+deps =
+commands = python -c 'from importlib.metadata import version; ver = version("{{package}}"); tag = "'{posargs}'"; error = f"`{ver}` != `{tag}`"; abort = f"Package version does not match the Git tag ({error}). ABORTING."; raise SystemExit(0 if ver and tag and ver == tag else abort)'
+
 [testenv:package]
 description = Build package and check metadata (or upload package)
 skip_install = true

--- a/examples/docopt/.gitlab-ci.yml
+++ b/examples/docopt/.gitlab-ci.yml
@@ -69,16 +69,7 @@ pypi-local:
     TWINE_PASSWORD: ${CI_JOB_TOKEN}
     TWINE_REPOSITORY_URL: ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/pypi
   script:
-  - |
-    tox -e package exec --quiet -- python -c '
-    from importlib.metadata import version
-    from os import environ
-    ver = version("{{package}}")
-    tag = environ.get("GIT_TAG") or ""
-    error = f"`{ver}` != `{tag}`"
-    abort = f"Package version does not match the Git tag ({error}). ABORTING."
-    raise SystemExit(0 if ver and tag and ver == tag else abort)
-    '
+  - tox -e ensure_version_matches -- ${GIT_TAG}
   - tox -e package -- upload
   only:
   - tags

--- a/examples/docopt/tox.ini
+++ b/examples/docopt/tox.ini
@@ -26,6 +26,11 @@ commands =
     pyclean {posargs:. --debris --erase junit-report.xml --yes}
     ruff clean
 
+[testenv:ensure_version_matches]
+description = Verify application version is same as Git tag
+deps =
+commands = python -c 'from importlib.metadata import version; ver = version("{{package}}"); tag = "'{posargs}'"; error = f"`{ver}` != `{tag}`"; abort = f"Package version does not match the Git tag ({error}). ABORTING."; raise SystemExit(0 if ver and tag and ver == tag else abort)'
+
 [testenv:package]
 description = Build package and check metadata (or upload package)
 skip_install = true


### PR DESCRIPTION
This follows the idea of keeping the pipeline implementation as dumb as possible.

- The (code of the) check can be executed (and hence verified) locally. :heavy_check_mark: 
- The pipeline implementation is simpler, hence easier to migrate to other CI systems. :heavy_check_mark: 

The change also removes a tricky complexity that is hard to investigate and troubleshoot: The version check requires that the package is installed, hence `skip_install = true` will break the environment. This was not immediately apparent with the original pipeline code, having the two sequential `tox` calls. The isolated execution of the two tasks/environments makes this more natural to understand.