### PR TITLE
Copier v8.0.0 requires a command argument

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -17,7 +17,7 @@ Then your directory layout looks somewhat like one of `our examples`_.
 
     .. code-block:: console
 
-        $ copier gh:painless-software/python-cli-test-helpers my-cli
+        $ copier copy gh:painless-software/python-cli-test-helpers my-cli
 
 .. _pytest: https://pytest.org/
 .. _our examples:

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -15,7 +15,7 @@ one of the CLI libraries above, e.g.
 
 .. code-block:: console
 
-    copier gh:painless-software/python-cli-test-helpers cli-example
+    copier copy gh:painless-software/python-cli-test-helpers cli-example
 
 Add the ``--vcs-ref HEAD`` option to pick all changes from the repository that
 might have been added after the latest release. See the `Copier documentation`_

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ description = Run test suite of example project
 skip_install = true
 deps = copier
 commands =
-    copier {toxinidir} {toxworkdir}/examples/argparse -d engine='Argparse' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
+    copier copy {toxinidir} {toxworkdir}/examples/argparse -d engine='Argparse' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
     tox -c {toxworkdir}/examples/argparse/tox.ini -e ruff
     tox -c {toxworkdir}/examples/argparse/tox.ini -e py -- -vv
 allowlist_externals =
@@ -73,7 +73,7 @@ description = Run test suite of example project
 skip_install = true
 deps = copier
 commands =
-    copier {toxinidir} {toxworkdir}/examples/click -d engine='Click' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
+    copier copy {toxinidir} {toxworkdir}/examples/click -d engine='Click' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
     tox -c {toxworkdir}/examples/click/tox.ini -e ruff
     tox -c {toxworkdir}/examples/click/tox.ini -e py -- -vv
 allowlist_externals =
@@ -84,7 +84,7 @@ description = Run test suite of example project
 skip_install = true
 deps = copier
 commands =
-    copier {toxinidir} {toxworkdir}/examples/docopt -d engine='Docopt' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
+    copier copy {toxinidir} {toxworkdir}/examples/docopt -d engine='Docopt' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
     tox -c {toxworkdir}/examples/docopt/tox.ini -e ruff
     tox -c {toxworkdir}/examples/docopt/tox.ini -e py -- -vv
 allowlist_externals =


### PR DESCRIPTION
Copier made a few breaking changes in [version v8.0.0](https://copier.readthedocs.io/en/stable/changelog/#v800-2023-06-04), which requires adapting our implementation.