### PR TITLE
Use Ruff to enforce code style (formatting)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,14 +20,15 @@ jobs:
       matrix:
         env:
         - ruff
+        - format
         - example-argparse
         - example-click
         - example-docopt
         - package
         - docs
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install prerequisites

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install prerequisites

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - '2.7'
         - '3.5'
         - '3.6'
         - '3.7'
@@ -31,15 +30,15 @@ jobs:
         - '3.9'
         - '3.10'
         - '3.11'
-        - pypy-2.7
+        - '3.12'
         - pypy-3.8
         - pypy-3.9
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install prerequisites
-      run: python -m pip install tox-gh-actions wheel
+      run: python -m pip install tox
     - name: Run tests
-      run: tox
+      run: tox -e py

--- a/cli_test_helpers/__init__.py
+++ b/cli_test_helpers/__init__.py
@@ -3,9 +3,9 @@ Useful helpers for writing tests for your Python CLI program.
 """
 
 __all__ = [
-    'ArgvContext',
-    'EnvironContext',
-    'shell',
+    "ArgvContext",
+    "EnvironContext",
+    "shell",
 ]
 
 from .commands import shell

--- a/cli_test_helpers/commands.py
+++ b/cli_test_helpers/commands.py
@@ -1,5 +1,5 @@
 """
-Useful commands for writing tests for your CLI tool
+Useful commands for writing tests for your CLI tool.
 """
 
 from sys import version_info
@@ -21,10 +21,11 @@ __all__ = []
 
 def shell(command, **kwargs):
     """
-    A better version of ``os.system()`` that captures output and returns a
-    convenient namespace object.
+    Execute a shell command capturing output and exit code.
+
+    This is a better version of ``os.system()`` that captures output and
+    returns a convenient namespace object.
     """
-    # pylint: disable=subprocess-run-check
     if version_info < (3, 5):  # Python 2.7
         completed = Namespace(returncode=None, stdout=b"", stderr=b"")
         try:
@@ -34,9 +35,10 @@ def shell(command, **kwargs):
             completed.stdout = ex.output
             completed.returncode = ex.returncode
     elif version_info < (3, 7):
-        completed = run(command, shell=True, stdout=PIPE, stderr=PIPE, **kwargs)
+        completed = run(
+            command, shell=True, stdout=PIPE, stderr=PIPE, check=False, **kwargs)
     else:
-        completed = run(command, shell=True, capture_output=True, **kwargs)
+        completed = run(command, shell=True, capture_output=True, check=False, **kwargs)
 
     return Namespace(
         exit_code=completed.returncode,

--- a/cli_test_helpers/commands.py
+++ b/cli_test_helpers/commands.py
@@ -36,7 +36,8 @@ def shell(command, **kwargs):
             completed.returncode = ex.returncode
     elif version_info < (3, 7):
         completed = run(
-            command, shell=True, stdout=PIPE, stderr=PIPE, check=False, **kwargs)
+            command, shell=True, stdout=PIPE, stderr=PIPE, check=False, **kwargs
+        )
     else:
         completed = run(command, shell=True, capture_output=True, check=False, **kwargs)
 

--- a/cli_test_helpers/decorators.py
+++ b/cli_test_helpers/decorators.py
@@ -1,5 +1,5 @@
 """
-Useful helpers for writing tests for your CLI tool
+Useful helpers for writing tests for your CLI tool.
 """
 
 import sys
@@ -14,7 +14,7 @@ __all__ = []
 
 class ArgvContext:
     """
-    A simple context manager allowing to temporarily override ``sys.argv``
+    A simple context manager allowing to temporarily override ``sys.argv``.
     """
 
     def __init__(self, *new_args):
@@ -48,7 +48,7 @@ class EnvironContext(patch.dict):
         for key in self.clear_variables:
             kwargs.pop(key)
 
-        super(EnvironContext, self).__init__('os.environ', **kwargs)
+        super(EnvironContext, self).__init__("os.environ", **kwargs)
 
     def __enter__(self):
 

--- a/cli_test_helpers/decorators.py
+++ b/cli_test_helpers/decorators.py
@@ -40,10 +40,7 @@ class EnvironContext(patch.dict):
     """
 
     def __init__(self, **kwargs):
-
-        self.clear_variables = [
-            key for key, val in kwargs.items() if val is None
-        ]
+        self.clear_variables = [key for key, val in kwargs.items() if val is None]
 
         for key in self.clear_variables:
             kwargs.pop(key)
@@ -51,7 +48,6 @@ class EnvironContext(patch.dict):
         super(EnvironContext, self).__init__("os.environ", **kwargs)
 
     def __enter__(self):
-
         super(EnvironContext, self).__enter__()
 
         for key in self.clear_variables:

--- a/examples/argparse/.gitlab-ci.yml
+++ b/examples/argparse/.gitlab-ci.yml
@@ -21,6 +21,12 @@ stages:
 - build
 - publish
 
+format:
+  stage: codestyle
+  extends: .tox
+  variables:
+    TOXENV: format
+
 ruff:
   stage: codestyle
   extends: .tox
@@ -39,6 +45,7 @@ pytest:
       - '3.9'
       - '3.10'
       - '3.11'
+      - '3.12'
   coverage: /^TOTAL.+?(\d+\%)$/
   artifacts:
     reports:

--- a/examples/argparse/pyproject.toml
+++ b/examples/argparse/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Utilities",
 ]
 keywords = [
@@ -39,9 +40,6 @@ dependencies = [
 [project.urls]
 homepage = "{{url}}"
 
-[tool.black]
-color = true
-
 [tool.coverage.run]
 source = ["{{module}}"]
 
@@ -52,10 +50,14 @@ show_missing = true
 addopts = "--color=yes --doctest-modules --junitxml=junit-report.xml --verbose"
 
 [tool.ruff]
-extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
-extend-ignore = ["B904"]
+extend-exclude = []
+extend-include = []
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint]
+extend-ignore = ["ANN", "B904", "D", "INP001", "T201", "TRY200"]
+extend-select = ["ALL"]
+
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = ["S101"]
 
 [tool.setuptools.packages.find]

--- a/examples/argparse/tests/test_cli.py
+++ b/examples/argparse/tests/test_cli.py
@@ -16,14 +16,14 @@ def test_main_module():
     """
     Exercise (most of) the code in the ``__main__`` module.
     """
-    import_module('{{module}}.__main__')
+    import_module("{{module}}.__main__")
 
 
 def test_runas_module():
     """
     Can this package be run as a Python module?
     """
-    result = shell('python -m {{module}} --help')
+    result = shell("python -m {{module}} --help")
     assert result.exit_code == 0
 
 
@@ -31,31 +31,31 @@ def test_entrypoint():
     """
     Is entrypoint script installed? (setup.py)
     """
-    result = shell('{{package}} --help')
+    result = shell("{{package}} --help")
     assert result.exit_code == 0
 
 
-@patch('{{module}}.cli.dispatch')
+@patch("{{module}}.cli.dispatch")
 def test_usage(mock_dispatch):
     """
     Does CLI abort w/o arguments, displaying usage instructions?
     """
-    with ArgvContext('{{package}}'), pytest.raises(SystemExit):
+    with ArgvContext("{{package}}"), pytest.raises(SystemExit):
         {{module}}.cli.main()
 
-    assert not mock_dispatch.called, 'CLI should stop execution'
+    assert not mock_dispatch.called, "CLI should stop execution"
 
-    result = shell('{{package}}')
+    result = shell("{{package}}")
 
-    assert 'usage:' in result.stderr
+    assert "usage:" in result.stderr
 
 
 def test_version():
     """
     Does --version display information as expected?
     """
-    expected_version = version('{{package}}')
-    result = shell('{{package}} --version')
+    expected_version = version("{{package}}")
+    result = shell("{{package}} --version")
 
     assert result.stdout == f"{expected_version}{linesep}"
     assert result.exit_code == 0
@@ -65,20 +65,20 @@ def test_get_action():
     """
     Is action argument available?
     """
-    with ArgvContext('{{package}}', 'get'):
+    with ArgvContext("{{package}}", "get"):
         args = {{module}}.cli.parse_arguments()
 
-    assert args.action == 'get'
+    assert args.action == "get"
 
 
 def test_set_action():
     """
     Is action argument available?
     """
-    with ArgvContext('{{package}}', 'set'):
+    with ArgvContext("{{package}}", "set"):
         args = {{module}}.cli.parse_arguments()
 
-    assert args.action == 'set'
+    assert args.action == "set"
 
 
 # NOTE:

--- a/examples/argparse/tests/test_command.py
+++ b/examples/argparse/tests/test_command.py
@@ -9,12 +9,12 @@ from cli_test_helpers import ArgvContext, EnvironContext
 import {{module}}
 
 
-@patch('{{module}}.command.example')
+@patch("{{module}}.command.example")
 def test_cli_command(mock_command):
     """
     Is the correct code called when invoked via the CLI?
     """
-    with ArgvContext('{{package}}', 'get'):
+    with ArgvContext("{{package}}", "get"):
         {{module}}.cli.main()
 
     assert mock_command.called
@@ -26,6 +26,6 @@ def test_fail_without_secret():
     """
     message_regex = "Environment value SECRET not set."
 
-    with ArgvContext('{{package}}', 'get'), EnvironContext(SECRET=None), \
+    with ArgvContext("{{package}}", "get"), EnvironContext(SECRET=None), \
             pytest.raises(SystemExit, match=message_regex):
         {{module}}.cli.main()

--- a/examples/argparse/tox.ini
+++ b/examples/argparse/tox.ini
@@ -18,12 +18,20 @@ commands =
 [testenv:clean]
 description = Remove bytecode and other debris
 skip_install = true
-deps =
-    pyclean
-    ruff
-commands =
-    pyclean {posargs:. --debris --erase junit-report.xml --yes}
-    ruff clean
+deps = pyclean
+commands = pyclean {posargs:. --debris --erase junit-report.xml --yes}
+
+[testenv:format]
+description = Ensure consistent code style
+skip_install = true
+deps = ruff
+commands = ruff format {posargs:--check --diff .}
+
+[testenv:ruff]
+description = Lightening-fast linting for Python
+skip_install = true
+deps = ruff
+commands = ruff {posargs:--show-source .}
 
 [testenv:ensure_version_matches]
 description = Verify package version is same as Git tag
@@ -43,9 +51,3 @@ passenv =
     TWINE_USERNAME
     TWINE_PASSWORD
     TWINE_REPOSITORY_URL
-
-[testenv:ruff]
-description = Lightening-fast linting for Python
-skip_install = true
-deps = ruff
-commands = ruff {posargs:. --show-source}

--- a/examples/argparse/{{module}}/__main__.py
+++ b/examples/argparse/{{module}}/__main__.py
@@ -3,5 +3,5 @@ Helper module to run not-installed version (via ``python3 -m {{module}}``).
 """
 from .cli import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()  # pragma: no cover

--- a/examples/argparse/{{module}}/cli.py
+++ b/examples/argparse/{{module}}/cli.py
@@ -9,21 +9,21 @@ from . import command
 
 def parse_arguments():
     """Parse and handle CLI arguments."""
-    __version__ = version('{{package}}')
+    __version__ = version("{{package}}")
 
-    parser = argparse.ArgumentParser(description='{{project}}')
+    parser = argparse.ArgumentParser(description="{{project}}")
 
-    parser.add_argument('--version', action='version', version=__version__)
-    parser.add_argument('action', choices=['get', 'set'])
-    parser.add_argument('envvar', nargs='?', default='SECRET',
-                        help='default: %(default)s')
+    parser.add_argument("--version", action="version", version=__version__)
+    parser.add_argument("action", choices=["get", "set"])
+    parser.add_argument("envvar", nargs="?", default="SECRET",
+                        help="default: %(default)s")
 
     return parser.parse_args()
 
 
 def dispatch(args):
     """Execute functionality requested through the CLI."""
-    if args.action == 'get':
+    if args.action == "get":
         command.example(args)
     else:
         raise NotImplementedError(args.action)

--- a/examples/argparse/{{module}}/command.py
+++ b/examples/argparse/{{module}}/command.py
@@ -8,7 +8,7 @@ def example(args):
     """An example command."""
     try:
         value = os.environ[args.envvar]
-        print(f'{args.envvar} = {value}')
+        print(f"{args.envvar} = {value}")
     except KeyError:
-        msg = f'Environment value {args.envvar} not set.'
+        msg = f"Environment value {args.envvar} not set."
         raise SystemExit(msg)

--- a/examples/click/.gitlab-ci.yml
+++ b/examples/click/.gitlab-ci.yml
@@ -22,6 +22,12 @@ stages:
 - build
 - publish
 
+format:
+  stage: codestyle
+  extends: .tox
+  variables:
+    TOXENV: format
+
 ruff:
   stage: codestyle
   extends: .tox
@@ -46,6 +52,7 @@ pytest:
       - '3.9'
       - '3.10'
       - '3.11'
+      - '3.12'
   coverage: /^TOTAL.+?(\d+\%)$/
   artifacts:
     reports:

--- a/examples/click/pyproject.toml
+++ b/examples/click/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Utilities",
 ]
 keywords = [
@@ -40,9 +41,6 @@ dependencies = [
 [project.urls]
 homepage = "{{url}}"
 
-[tool.black]
-color = true
-
 [tool.coverage.run]
 source = ["{{module}}"]
 
@@ -53,10 +51,14 @@ show_missing = true
 addopts = "--color=yes --doctest-modules --junitxml=junit-report.xml --verbose"
 
 [tool.ruff]
-extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
-extend-ignore = ["B904"]
+extend-exclude = []
+extend-include = []
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint]
+extend-ignore = ["ANN", "B904", "D", "INP001", "TRY200"]
+extend-select = ["ALL"]
+
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = ["S101"]
 
 [tool.setuptools.packages.find]

--- a/examples/click/tests/test_cli.py
+++ b/examples/click/tests/test_cli.py
@@ -15,14 +15,14 @@ def test_main_module():
     """
     Exercise (most of) the code in the ``__main__`` module.
     """
-    import_module('{{module}}.__main__')
+    import_module("{{module}}.__main__")
 
 
 def test_runas_module():
     """
     Can this package be run as a Python module?
     """
-    result = shell('python -m {{module}} --help')
+    result = shell("python -m {{module}} --help")
     assert result.exit_code == 0
 
 
@@ -30,7 +30,7 @@ def test_entrypoint():
     """
     Is entrypoint script installed? (setup.py)
     """
-    result = shell('{{package}} --help')
+    result = shell("{{package}} --help")
     assert result.exit_code == 0
 
 
@@ -41,7 +41,7 @@ def test_usage():
     runner = CliRunner()
     result = runner.invoke({{module}}.cli.main)
 
-    assert 'Usage:' in result.output
+    assert "Usage:" in result.output
     assert result.exit_code != 0
 
 
@@ -49,8 +49,8 @@ def test_version():
     """
     Does --version display information as expected?
     """
-    expected_version = version('{{package}}')
-    result = shell('{{package}} --version')
+    expected_version = version("{{package}}")
+    result = shell("{{package}} --version")
 
     assert result.stdout == f"{{package}}, version {expected_version}{linesep}"
     assert result.exit_code == 0
@@ -60,7 +60,7 @@ def test_example_command():
     """
     Is command available?
     """
-    result = shell('{{package}} example --help')
+    result = shell("{{package}} example --help")
     assert result.exit_code == 0
 
 

--- a/examples/click/tests/test_command.py
+++ b/examples/click/tests/test_command.py
@@ -9,12 +9,12 @@ from cli_test_helpers import ArgvContext, EnvironContext
 import {{module}}
 
 
-@patch('{{module}}.command.example')
+@patch("{{module}}.command.example")
 def test_cli_command(mock_command):
     """
     Is the correct code called when invoked via the CLI?
     """
-    with ArgvContext('{{package}}', 'example'), pytest.raises(SystemExit):
+    with ArgvContext("{{package}}", "example"), pytest.raises(SystemExit):
         {{module}}.cli.main()
 
     assert mock_command.called
@@ -27,4 +27,4 @@ def test_fail_without_secret():
     message_regex = "Environment value SECRET not set."
 
     with EnvironContext(SECRET=None), pytest.raises(SystemExit, match=message_regex):
-        {{module}}.command.example('SECRET')
+        {{module}}.command.example("SECRET")

--- a/examples/click/tox.ini
+++ b/examples/click/tox.ini
@@ -19,12 +19,20 @@ commands =
 [testenv:clean]
 description = Remove bytecode and other debris
 skip_install = true
-deps =
-    pyclean
-    ruff
-commands =
-    pyclean {posargs:. --debris --erase junit-report.xml --yes}
-    ruff clean
+deps = pyclean
+commands = pyclean {posargs:. --debris --erase junit-report.xml --yes}
+
+[testenv:format]
+description = Ensure consistent code style
+skip_install = true
+deps = ruff
+commands = ruff format {posargs:--check --diff .}
+
+[testenv:ruff]
+description = Lightening-fast linting for Python
+skip_install = true
+deps = ruff
+commands = ruff {posargs:--show-source .}
 
 [testenv:ensure_version_matches]
 description = Verify package version is same as Git tag
@@ -54,9 +62,3 @@ commands =
     git diff --color --exit-code requirements.txt
 allowlist_externals =
     git
-
-[testenv:ruff]
-description = Lightening-fast linting for Python
-skip_install = true
-deps = ruff
-commands = ruff {posargs:. --show-source}

--- a/examples/click/{{module}}/__main__.py
+++ b/examples/click/{{module}}/__main__.py
@@ -3,5 +3,5 @@ Helper module to run not-installed version (via ``python3 -m {{module}}``).
 """
 from .cli import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()  # pragma: no cover

--- a/examples/click/{{module}}/cli.py
+++ b/examples/click/{{module}}/cli.py
@@ -8,7 +8,7 @@ from . import command
 
 @click.command()
 @click.version_option()
-@click.argument('envvar')
+@click.argument("envvar")
 def main(envvar):
     """{{project}}"""
     command.example(envvar)

--- a/examples/click/{{module}}/command.py
+++ b/examples/click/{{module}}/command.py
@@ -3,12 +3,14 @@ Example command module.
 """
 import os
 
+import click
+
 
 def example(envvar):
     """An example command."""
     try:
         value = os.environ[envvar]
-        print(f'{envvar} = {value}')
+        click.echo(f"{envvar} = {value}")
     except KeyError:
-        msg = f'Environment value {envvar} not set.'
+        msg = f"Environment value {envvar} not set."
         raise SystemExit(msg)

--- a/examples/docopt/.gitlab-ci.yml
+++ b/examples/docopt/.gitlab-ci.yml
@@ -22,6 +22,12 @@ stages:
 - build
 - publish
 
+format:
+  stage: codestyle
+  extends: .tox
+  variables:
+    TOXENV: format
+
 ruff:
   stage: codestyle
   extends: .tox
@@ -46,6 +52,7 @@ pytest:
       - '3.9'
       - '3.10'
       - '3.11'
+      - '3.12'
   coverage: /^TOTAL.+?(\d+\%)$/
   artifacts:
     reports:

--- a/examples/docopt/pyproject.toml
+++ b/examples/docopt/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Utilities",
 ]
 keywords = [
@@ -40,9 +41,6 @@ dependencies = [
 [project.urls]
 homepage = "{{url}}"
 
-[tool.black]
-color = true
-
 [tool.coverage.run]
 source = ["{{module}}"]
 
@@ -53,10 +51,14 @@ show_missing = true
 addopts = "--color=yes --doctest-modules --junitxml=junit-report.xml --verbose"
 
 [tool.ruff]
-extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
-extend-ignore = ["B904"]
+extend-exclude = []
+extend-include = []
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint]
+extend-ignore = ["ANN", "B904", "D", "INP001", "T201", "TRY200"]
+extend-select = ["ALL"]
+
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = ["S101"]
 
 [tool.setuptools.packages.find]

--- a/examples/docopt/tests/test_cli.py
+++ b/examples/docopt/tests/test_cli.py
@@ -16,14 +16,14 @@ def test_main_module():
     """
     Exercise (most of) the code in the ``__main__`` module.
     """
-    import_module('{{module}}.__main__')
+    import_module("{{module}}.__main__")
 
 
 def test_runas_module():
     """
     Can this package be run as a Python module?
     """
-    result = shell('python -m {{module}} --help')
+    result = shell("python -m {{module}} --help")
     assert result.exit_code == 0
 
 
@@ -31,31 +31,31 @@ def test_entrypoint():
     """
     Is entrypoint script installed? (setup.py)
     """
-    result = shell('{{package}} --help')
+    result = shell("{{package}} --help")
     assert result.exit_code == 0
 
 
-@patch('{{module}}.command.dispatch')
+@patch("{{module}}.command.dispatch")
 def test_usage(mock_dispatch):
     """
     Does CLI abort w/o arguments, displaying usage instructions?
     """
-    with ArgvContext('{{package}}'), pytest.raises(SystemExit):
+    with ArgvContext("{{package}}"), pytest.raises(SystemExit):
         {{module}}.cli.main()
 
-    assert not mock_dispatch.called, 'CLI should stop execution'
+    assert not mock_dispatch.called, "CLI should stop execution"
 
-    result = shell('{{package}}')
+    result = shell("{{package}}")
 
-    assert 'Usage:' in result.stderr
+    assert "Usage:" in result.stderr
 
 
 def test_version():
     """
     Does --version display information as expected?
     """
-    expected_version = version('{{package}}')
-    result = shell('{{package}} --version')
+    expected_version = version("{{package}}")
+    result = shell("{{package}} --version")
 
     assert result.stdout == f"{expected_version}{linesep}"
     assert result.exit_code == 0
@@ -65,7 +65,7 @@ def test_file_argument():
     """
     Is the positional parameter available?
     """
-    result = shell('{{package}} myfile --help')
+    result = shell("{{package}} myfile --help")
     assert result.exit_code == 0
 
 
@@ -75,19 +75,19 @@ def test_file_argument():
 # availability of the CLI command or option.
 
 
-@pytest.mark.parametrize(('option', 'silent', 'verbose'), [
-    ('-s', True, False),
-    ('-v', False, True),
-    ('--silent', True, False),
-    ('--verbose', False, True),
+@pytest.mark.parametrize(("option", "silent", "verbose"), [
+    ("-s", True, False),
+    ("-v", False, True),
+    ("--silent", True, False),
+    ("--verbose", False, True),
 ])
 def test_options(option, silent, verbose):
     """
     Is the (-s | --silent) and (-v | --verbose) option evaluated correctly?
     """
-    with ArgvContext('{{package}}', 'myfile', option):
+    with ArgvContext("{{package}}", "myfile", option):
         args = {{module}}.cli.parse_arguments()
 
-    assert args['file'] == 'myfile'
-    assert args['silent'] == silent
-    assert args['verbose'] == verbose
+    assert args["file"] == "myfile"
+    assert args["silent"] == silent
+    assert args["verbose"] == verbose

--- a/examples/docopt/tests/test_command.py
+++ b/examples/docopt/tests/test_command.py
@@ -8,31 +8,31 @@ from cli_test_helpers import ArgvContext
 import {{module}}
 
 
-@patch('{{module}}.command.dispatch')
+@patch("{{module}}.command.dispatch")
 def test_dispatch_is_called(mock_dispatch):
     """
     Is the correct code called when invoked via the CLI?
     """
-    with ArgvContext('{{package}}', 'myfile', '-v'):
+    with ArgvContext("{{package}}", "myfile", "-v"):
         {{module}}.cli.main()
 
     assert mock_dispatch.called
     assert mock_dispatch.call_args.kwargs == {
-        'file': 'myfile',
-        'silent': False,
-        'verbose': True,
+        "file": "myfile",
+        "silent": False,
+        "verbose": True,
     }
 
 
-@patch('{{module}}.command.print')
-@patch('{{module}}.command.Path.open')
+@patch("{{module}}.command.print")
+@patch("{{module}}.command.Path.open")
 def test_dispatch_business_logic(mock_openfile, mock_print):
     """
     Walk the code of the dispatch function.
     """
     expected_print_calls = 3
 
-    {{module}}.command.dispatch(file='myfile', silent=False, verbose=True)
+    {{module}}.command.dispatch(file="myfile", silent=False, verbose=True)
 
     assert mock_openfile.called
     assert mock_print.call_count == expected_print_calls, \

--- a/examples/docopt/tox.ini
+++ b/examples/docopt/tox.ini
@@ -19,12 +19,20 @@ commands =
 [testenv:clean]
 description = Remove bytecode and other debris
 skip_install = true
-deps =
-    pyclean
-    ruff
-commands =
-    pyclean {posargs:. --debris --erase junit-report.xml --yes}
-    ruff clean
+deps = pyclean
+commands = pyclean {posargs:. --debris --erase junit-report.xml --yes}
+
+[testenv:format]
+description = Ensure consistent code style
+skip_install = true
+deps = ruff
+commands = ruff format {posargs:--check --diff .}
+
+[testenv:ruff]
+description = Lightening-fast linting for Python
+skip_install = true
+deps = ruff
+commands = ruff {posargs:--show-source .}
 
 [testenv:ensure_version_matches]
 description = Verify package version is same as Git tag
@@ -54,9 +62,3 @@ commands =
     git diff --color --exit-code requirements.txt
 allowlist_externals =
     git
-
-[testenv:ruff]
-description = Lightening-fast linting for Python
-skip_install = true
-deps = ruff
-commands = ruff {posargs:. --show-source}

--- a/examples/docopt/{{module}}/__main__.py
+++ b/examples/docopt/{{module}}/__main__.py
@@ -3,5 +3,5 @@ Helper module to run not-installed version (via ``python3 -m {{module}}``).
 """
 from .cli import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()  # pragma: no cover

--- a/examples/docopt/{{module}}/cli.py
+++ b/examples/docopt/{{module}}/cli.py
@@ -25,12 +25,12 @@ from . import command
 
 def parse_arguments():
     """Parse and handle CLI arguments."""
-    args = docopt(__doc__, version=version('{{package}}'))
+    args = docopt(__doc__, version=version("{{package}}"))
 
     return {
-        "file": args['<file>'],
-        "silent": args['--silent'],
-        "verbose": args['--verbose'],
+        "file": args["<file>"],
+        "silent": args["--silent"],
+        "verbose": args["--verbose"],
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,25 @@ show_missing = true
 addopts = "--color=yes --doctest-modules --ignore examples/ --junitxml=tests/junit-report.xml --verbose"
 
 [tool.ruff]
-extend-exclude = ["examples"]
-extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
-extend-ignore = ["SIM105"]  # Python 2.7 only
+extend-exclude = ["docs/conf.py", "examples", "setup.py"]
+extend-include = []
 
-[tool.ruff.per-file-ignores]
-"cli_test_helpers/commands.py" = ["S602"]
-"setup.py" = ["PTH"]
-"tests/*.py" = ["S101"]
+[tool.ruff.lint]
+extend-select = ["ALL"]
+extend-ignore = [
+    "ANN",
+    "D200",
+    "D205",
+    "D212",
+    "Q000",
+    "PERF203",  # Python < 3.4 (`contextlib.suppress`)
+    "SIM105",  # Python 2.7 only
+    "UP008",  # Python 2.7 only (`super()` call)
+    "UP022",  # Python 2.7 only (`stderr=PIPE`)
+    "UP026",  # Python 2.7 only (`mock` module)
+    "UP036",  # Python < 3.7 only
+]
+
+[tool.ruff.lint.per-file-ignores]
+"cli_test_helpers/commands.py" = ["COM812", "S602"]
+"tests/*.py" = ["D400", "INP001", "S101"]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read_file(filename):
 
 setup(
     name='cli-test-helpers',
-    version='3.4.0',
+    version='3.5.0',
     author='Peter Bittner',
     author_email='peter@painless.software',
     description='Useful helpers for writing tests for your Python CLI program.',
@@ -38,8 +38,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
@@ -48,6 +46,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Testing',

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,5 +1,5 @@
 """
-Tests for our cli test commands
+Tests for our cli test commands.
 """
 from os import linesep
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,5 +1,5 @@
 """
-Tests for our tests helpers  8-}
+Tests for our tests helpers.  8-}.
 """
 import os
 import sys
@@ -17,8 +17,9 @@ def test_argv_context():
     assert sys.argv == old
 
     with ArgvContext(*new):
-        assert sys.argv == new, \
-            "sys.argv wasn't correctly changed by the contextmanager"
+        assert (
+            sys.argv == new
+        ), "sys.argv wasn't correctly changed by the contextmanager"
 
     assert sys.argv == old, "sys.argv wasn't correctly reset"
 
@@ -28,18 +29,20 @@ def test_environ_context():
     Does EnvironContext set new environ values and reset old ones correctly?
     """
     old_environ = os.environ
-    old_path = os.getenv('PATH')
+    old_path = os.getenv("PATH")
 
     assert os.environ == old_environ
-    assert os.getenv('PATH') is not None, "Invalid test setup"
-    assert os.getenv('FOO') is None, "Invalid test setup"
+    assert os.getenv("PATH") is not None, "Invalid test setup"
+    assert os.getenv("FOO") is None, "Invalid test setup"
 
-    with EnvironContext(PATH=None, FOO='my foo value'):
-        assert os.getenv('PATH') is None, \
-            "os.environ[PATH] wasn't removed by the contextmanager"
-        assert os.getenv('FOO') == 'my foo value', \
-            "os.environ[FOO] wasn't set by the contextmanager"
+    with EnvironContext(PATH=None, FOO="my foo value"):
+        assert (
+            os.getenv("PATH") is None
+        ), "os.environ[PATH] wasn't removed by the contextmanager"
+        assert (
+            os.getenv("FOO") == "my foo value"
+        ), "os.environ[FOO] wasn't set by the contextmanager"
 
     assert os.environ == old_environ, "object os.environ was not restored"
-    assert os.getenv('PATH') == old_path, "env var PATH was not restored"
-    assert os.getenv('FOO') is None, "env var FOO was not cleared"
+    assert os.getenv("PATH") == old_path, "env var PATH was not restored"
+    assert os.getenv("FOO") is None, "env var FOO was not cleared"

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,8 @@
 [tox]
 envlist =
     ruff
-    py2{7}
-    pypy2{7}
-    py3{5,6,7,8,9,10,11}
+    format
+    py3{5,6,7,8,9,10,11,12}
     pypy3{8,9}
     example-{argparse,click,docopt}
     package
@@ -16,7 +15,6 @@ envlist =
 [gh-actions]
 fail_on_no_env = True
 python =
-    2.7: py27
     3.5: py35
     3.6: py36
     3.7: py37
@@ -24,14 +22,14 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
-    pypy-2.7: pypy27
+    3.12: py312
     pypy-3.8: pypy38
     pypy-3.9: pypy39
 
 [testenv]
 description = Unit tests
 deps =
-    py3{9,10,11}: setuptools>=50
+    py3{9,10,11,12}: setuptools>=50
     coverage[toml]
     pytest
 commands =
@@ -42,12 +40,8 @@ commands =
 [testenv:clean]
 description = Remove bytecode and other debris
 skip_install = true
-deps =
-    pyclean
-    ruff
-commands =
-    pyclean {posargs:. --debris --erase docs/_build/**/* docs/_build/ tests/junit-report.xml --yes --verbose}
-    ruff clean
+deps = pyclean
+commands = pyclean {posargs:. --debris --erase docs/_build/**/* docs/_build/ tests/junit-report.xml --yes --verbose}
 
 [testenv:docs]
 description = Build package documentation (HTML)
@@ -115,10 +109,3 @@ description = Lightening-fast linting for Python
 skip_install = true
 deps = ruff
 commands = ruff {posargs:--show-source .}
-
-[pytest]
-addopts =
-    --color=yes
-    --doctest-modules
-    --verbose
-    --ignore examples/

--- a/tox.ini
+++ b/tox.ini
@@ -90,6 +90,12 @@ commands =
 allowlist_externals =
     tox
 
+[testenv:format]
+description = Ensure consistent code style
+skip_install = true
+deps = ruff
+commands = ruff format {posargs:--check --diff .}
+
 [testenv:package]
 description = Build package and check metadata (or upload package)
 skip_install = true
@@ -108,7 +114,7 @@ passenv =
 description = Lightening-fast linting for Python
 skip_install = true
 deps = ruff
-commands = ruff {posargs:. --show-source}
+commands = ruff {posargs:--show-source .}
 
 [pytest]
 addopts =


### PR DESCRIPTION
- Activates code formatting check (via Ruff)
- Changes formatting of project code and of example to satisfy Ruff
- Drops Python 2.7 in CI (since unsupported by GHA)
- Bumps version (3.4.0 ➜ 3.5.0)