### PR TITLE
Drop support for Python 2.7, 3.5, 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,12 +62,7 @@ this:
 
 .. code-block:: shell
 
-    python3 -m pip install tox 'virtualenv<20.22'
-
-.. note::
-
-   Virtualenv 20.22 dropped support for Python 2.7 and <3.6, which most
-   notably makes Tox fail to detect the PyPy2 executable.
+    python3 -m pip install tox
 
 .. code-block:: shell
 

--- a/cli_test_helpers/commands.py
+++ b/cli_test_helpers/commands.py
@@ -2,13 +2,8 @@
 Useful commands for writing tests for your CLI tool.
 """
 
-from sys import version_info
+from subprocess import run
 from types import SimpleNamespace as Namespace
-
-if version_info < (3, 7):
-    from subprocess import PIPE, run
-else:
-    from subprocess import run
 
 __all__ = []
 
@@ -20,12 +15,7 @@ def shell(command, **kwargs):
     This is a better version of ``os.system()`` that captures output and
     returns a convenient namespace object.
     """
-    if version_info < (3, 7):
-        completed = run(
-            command, shell=True, stdout=PIPE, stderr=PIPE, check=False, **kwargs
-        )
-    else:
-        completed = run(command, shell=True, capture_output=True, check=False, **kwargs)
+    completed = run(command, shell=True, capture_output=True, check=False, **kwargs)
 
     return Namespace(
         exit_code=completed.returncode,

--- a/cli_test_helpers/commands.py
+++ b/cli_test_helpers/commands.py
@@ -3,15 +3,9 @@ Useful commands for writing tests for your CLI tool.
 """
 
 from sys import version_info
+from types import SimpleNamespace as Namespace
 
-try:
-    from types import SimpleNamespace as Namespace
-except ImportError:  # Python < 3.3
-    from argparse import Namespace
-
-if version_info < (3, 5):  # Python 2.7
-    from subprocess import PIPE, CalledProcessError, check_output
-elif version_info < (3, 7):
+if version_info < (3, 7):
     from subprocess import PIPE, run
 else:
     from subprocess import run
@@ -26,15 +20,7 @@ def shell(command, **kwargs):
     This is a better version of ``os.system()`` that captures output and
     returns a convenient namespace object.
     """
-    if version_info < (3, 5):  # Python 2.7
-        completed = Namespace(returncode=None, stdout=b"", stderr=b"")
-        try:
-            completed.stdout = check_output(command, shell=True, stderr=PIPE, **kwargs)
-            completed.returncode = 0
-        except CalledProcessError as ex:
-            completed.stdout = ex.output
-            completed.returncode = ex.returncode
-    elif version_info < (3, 7):
+    if version_info < (3, 7):
         completed = run(
             command, shell=True, stdout=PIPE, stderr=PIPE, check=False, **kwargs
         )

--- a/cli_test_helpers/decorators.py
+++ b/cli_test_helpers/decorators.py
@@ -2,12 +2,9 @@
 Useful helpers for writing tests for your CLI tool.
 """
 
+import contextlib
 import sys
-
-try:
-    from unittest.mock import patch
-except ImportError:  # Python 2.7
-    from mock import patch
+from unittest.mock import patch
 
 __all__ = []
 
@@ -45,13 +42,11 @@ class EnvironContext(patch.dict):
         for key in self.clear_variables:
             kwargs.pop(key)
 
-        super(EnvironContext, self).__init__("os.environ", **kwargs)
+        super().__init__("os.environ", **kwargs)
 
     def __enter__(self):
-        super(EnvironContext, self).__enter__()
+        super().__enter__()
 
         for key in self.clear_variables:
-            try:
+            with contextlib.suppress(KeyError):
                 self.in_dict.pop(key)
-            except KeyError:
-                pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,11 +65,7 @@ extend-ignore = [
     "D205",
     "D212",
     "Q000",
-    "PERF203",  # Python < 3.4 (`contextlib.suppress`)
-    "SIM105",  # Python 2.7 only
-    "UP008",  # Python 2.7 only (`super()` call)
-    "UP022",  # Python 2.7 only (`stderr=PIPE`)
-    "UP026",  # Python 2.7 only (`mock` module)
+    "UP022",  # Python < 3.7 only (`stderr=PIPE`)
     "UP036",  # Python < 3.7 only
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
@@ -38,6 +39,7 @@ keywords = [
   "testing",
   "helpers",
 ]
+requires-python = ">=3.7"
 
 [project.urls]
 homepage = "https://github.com/painless-software/python-cli-test-helpers"
@@ -65,12 +67,10 @@ extend-ignore = [
     "D205",
     "D212",
     "Q000",
-    "UP022",  # Python < 3.7 only (`stderr=PIPE`)
-    "UP036",  # Python < 3.7 only
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"cli_test_helpers/commands.py" = ["COM812", "S602"]
+"cli_test_helpers/commands.py" = ["S602"]
 "tests/*.py" = ["D400", "INP001", "S101"]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cli-test-helpers"
-version = "3.5.0"
+version = "4.0.0"
 description = "Useful helpers for writing tests for your Python CLI program."
 readme = "README.rst"
 license = {file = "LICENSE"}

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ envlist =
 [testenv]
 description = Unit tests
 deps =
-    py3{9,10,11,12}: setuptools>=50
     coverage[toml]
     pytest
 commands =


### PR DESCRIPTION
Removes backward-compatible Python code constructions, effectively dropping support for Python < 3.7.

If you need to use this package for Python < 3.7 you should install `cli-test-helpers<3.5.0`.