### PR TITLE
Use common job names for linting and formatting (Ruff)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
-        - ruff
+        - lint
         - format
         - example-argparse
         - example-click

--- a/examples/argparse/.gitlab-ci.yml
+++ b/examples/argparse/.gitlab-ci.yml
@@ -27,11 +27,11 @@ format:
   variables:
     TOXENV: format
 
-ruff:
+lint:
   stage: codestyle
   extends: .tox
   variables:
-    TOXENV: ruff
+    TOXENV: lint
 
 pytest:
   stage: test
@@ -41,7 +41,6 @@ pytest:
   parallel:
     matrix:
     - PYTHON_VERSION:
-      - '3.8'
       - '3.9'
       - '3.10'
       - '3.11'

--- a/examples/argparse/pyproject.toml
+++ b/examples/argparse/pyproject.toml
@@ -43,7 +43,9 @@ homepage = "{{url}}"
 source = ["{{module}}"]
 
 [tool.coverage.report]
+exclude_lines = ["if __name__ == .__main__.:"]
 show_missing = true
+skip_covered = true
 
 [tool.pytest.ini_options]
 addopts = "--color=yes --doctest-modules --junitxml=junit-report.xml --verbose"

--- a/examples/argparse/pyproject.toml
+++ b/examples/argparse/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
   "Intended Audience :: Information Technology",
   "License :: Other/Proprietary License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -30,7 +29,7 @@ classifiers = [
 keywords = [
   "cli",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
 ]
 
@@ -58,7 +57,7 @@ extend-ignore = ["ANN", "B904", "D", "INP001", "T201", "TRY200"]
 extend-select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*.py" = ["S101"]
+"test_*.py" = ["S101"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/examples/argparse/tests/test_command.py
+++ b/examples/argparse/tests/test_command.py
@@ -26,6 +26,8 @@ def test_fail_without_secret():
     """
     message_regex = "Environment value SECRET not set."
 
-    with ArgvContext("{{package}}", "get"), EnvironContext(SECRET=None), \
-            pytest.raises(SystemExit, match=message_regex):
+    with ArgvContext("{{package}}", "get"), EnvironContext(SECRET=None), pytest.raises(
+        SystemExit,
+        match=message_regex,
+    ):
         {{module}}.cli.main()

--- a/examples/argparse/tox.ini
+++ b/examples/argparse/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    ruff
-    py3{8,9,10,11}
+    lint
+    format
+    py3{9,10,11,12}
     package
 
 [testenv]
@@ -21,22 +22,22 @@ skip_install = true
 deps = pyclean
 commands = pyclean {posargs:. --debris --erase junit-report.xml --yes}
 
-[testenv:format]
-description = Ensure consistent code style
-skip_install = true
-deps = ruff
-commands = ruff format {posargs:--check --diff .}
-
-[testenv:ruff]
-description = Lightening-fast linting for Python
-skip_install = true
-deps = ruff
-commands = ruff {posargs:--show-source .}
-
 [testenv:ensure_version_matches]
 description = Verify package version is same as Git tag
 deps =
 commands = python -c 'from importlib.metadata import version; ver = version("{{package}}"); tag = "'{posargs}'"; error = f"`{ver}` != `{tag}`"; abort = f"Package version does not match the Git tag ({error}). ABORTING."; raise SystemExit(0 if ver and tag and ver == tag else abort)'
+
+[testenv:format]
+description = Ensure consistent code style (Ruff)
+skip_install = true
+deps = ruff
+commands = ruff format {posargs:--check --diff .}
+
+[testenv:lint]
+description = Lightening-fast linting (Ruff)
+skip_install = true
+deps = ruff
+commands = ruff check {posargs:--show-source .}
 
 [testenv:package]
 description = Build package and check metadata (or upload package)

--- a/examples/argparse/{{module}}/__main__.py
+++ b/examples/argparse/{{module}}/__main__.py
@@ -4,4 +4,4 @@ Helper module to run not-installed version (via ``python3 -m {{module}}``).
 from .cli import main
 
 if __name__ == "__main__":
-    main()  # pragma: no cover
+    main()

--- a/examples/argparse/{{module}}/cli.py
+++ b/examples/argparse/{{module}}/cli.py
@@ -15,8 +15,12 @@ def parse_arguments():
 
     parser.add_argument("--version", action="version", version=__version__)
     parser.add_argument("action", choices=["get", "set"])
-    parser.add_argument("envvar", nargs="?", default="SECRET",
-                        help="default: %(default)s")
+    parser.add_argument(
+        "envvar",
+        nargs="?",
+        default="SECRET",
+        help="default: %(default)s",
+    )
 
     return parser.parse_args()
 

--- a/examples/click/.gitlab-ci.yml
+++ b/examples/click/.gitlab-ci.yml
@@ -28,11 +28,11 @@ format:
   variables:
     TOXENV: format
 
-ruff:
+lint:
   stage: codestyle
   extends: .tox
   variables:
-    TOXENV: ruff
+    TOXENV: lint
 
 requirements:
   stage: safety
@@ -48,7 +48,6 @@ pytest:
   parallel:
     matrix:
     - PYTHON_VERSION:
-      - '3.8'
       - '3.9'
       - '3.10'
       - '3.11'

--- a/examples/click/pyproject.toml
+++ b/examples/click/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
   "Intended Audience :: Information Technology",
   "License :: Other/Proprietary License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -30,7 +29,7 @@ classifiers = [
 keywords = [
   "cli",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "click",
 ]
@@ -59,7 +58,7 @@ extend-ignore = ["ANN", "B904", "D", "INP001", "TRY200"]
 extend-select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*.py" = ["S101"]
+"test_*.py" = ["S101"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/examples/click/pyproject.toml
+++ b/examples/click/pyproject.toml
@@ -44,7 +44,9 @@ homepage = "{{url}}"
 source = ["{{module}}"]
 
 [tool.coverage.report]
+exclude_lines = ["if __name__ == .__main__.:"]
 show_missing = true
+skip_covered = true
 
 [tool.pytest.ini_options]
 addopts = "--color=yes --doctest-modules --junitxml=junit-report.xml --verbose"

--- a/examples/click/tox.ini
+++ b/examples/click/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    ruff
-    py3{8,9,10,11}
+    lint
+    format
+    py3{9,10,11,12}
     requirements
     package
 
@@ -22,22 +23,22 @@ skip_install = true
 deps = pyclean
 commands = pyclean {posargs:. --debris --erase junit-report.xml --yes}
 
-[testenv:format]
-description = Ensure consistent code style
-skip_install = true
-deps = ruff
-commands = ruff format {posargs:--check --diff .}
-
-[testenv:ruff]
-description = Lightening-fast linting for Python
-skip_install = true
-deps = ruff
-commands = ruff {posargs:--show-source .}
-
 [testenv:ensure_version_matches]
 description = Verify package version is same as Git tag
 deps =
 commands = python -c 'from importlib.metadata import version; ver = version("{{package}}"); tag = "'{posargs}'"; error = f"`{ver}` != `{tag}`"; abort = f"Package version does not match the Git tag ({error}). ABORTING."; raise SystemExit(0 if ver and tag and ver == tag else abort)'
+
+[testenv:format]
+description = Ensure consistent code style (Ruff)
+skip_install = true
+deps = ruff
+commands = ruff format {posargs:--check --diff .}
+
+[testenv:lint]
+description = Lightening-fast linting (Ruff)
+skip_install = true
+deps = ruff
+commands = ruff check {posargs:--show-source .}
 
 [testenv:package]
 description = Build package and check metadata (or upload package)

--- a/examples/click/{{module}}/__main__.py
+++ b/examples/click/{{module}}/__main__.py
@@ -4,4 +4,4 @@ Helper module to run not-installed version (via ``python3 -m {{module}}``).
 from .cli import main
 
 if __name__ == "__main__":
-    main()  # pragma: no cover
+    main()

--- a/examples/docopt/.gitlab-ci.yml
+++ b/examples/docopt/.gitlab-ci.yml
@@ -28,11 +28,11 @@ format:
   variables:
     TOXENV: format
 
-ruff:
+lint:
   stage: codestyle
   extends: .tox
   variables:
-    TOXENV: ruff
+    TOXENV: lint
 
 requirements:
   stage: safety
@@ -48,7 +48,6 @@ pytest:
   parallel:
     matrix:
     - PYTHON_VERSION:
-      - '3.8'
       - '3.9'
       - '3.10'
       - '3.11'

--- a/examples/docopt/pyproject.toml
+++ b/examples/docopt/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
   "Intended Audience :: Information Technology",
   "License :: Other/Proprietary License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -30,7 +29,7 @@ classifiers = [
 keywords = [
   "cli",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "docopt-ng",
 ]
@@ -59,7 +58,7 @@ extend-ignore = ["ANN", "B904", "D", "INP001", "T201", "TRY200"]
 extend-select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*.py" = ["S101"]
+"test_*.py" = ["S101"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/examples/docopt/pyproject.toml
+++ b/examples/docopt/pyproject.toml
@@ -44,7 +44,9 @@ homepage = "{{url}}"
 source = ["{{module}}"]
 
 [tool.coverage.report]
+exclude_lines = ["if __name__ == .__main__.:"]
 show_missing = true
+skip_covered = true
 
 [tool.pytest.ini_options]
 addopts = "--color=yes --doctest-modules --junitxml=junit-report.xml --verbose"

--- a/examples/docopt/tests/test_cli.py
+++ b/examples/docopt/tests/test_cli.py
@@ -75,12 +75,15 @@ def test_file_argument():
 # availability of the CLI command or option.
 
 
-@pytest.mark.parametrize(("option", "silent", "verbose"), [
-    ("-s", True, False),
-    ("-v", False, True),
-    ("--silent", True, False),
-    ("--verbose", False, True),
-])
+@pytest.mark.parametrize(
+    ("option", "silent", "verbose"),
+    [
+        ("-s", True, False),
+        ("-v", False, True),
+        ("--silent", True, False),
+        ("--verbose", False, True),
+    ],
+)
 def test_options(option, silent, verbose):
     """
     Is the (-s | --silent) and (-v | --verbose) option evaluated correctly?

--- a/examples/docopt/tests/test_command.py
+++ b/examples/docopt/tests/test_command.py
@@ -35,5 +35,6 @@ def test_dispatch_business_logic(mock_openfile, mock_print):
     {{module}}.command.dispatch(file="myfile", silent=False, verbose=True)
 
     assert mock_openfile.called
-    assert mock_print.call_count == expected_print_calls, \
-        "Expected 2x for --verbose, 1x for not --silent"
+    assert (
+        mock_print.call_count == expected_print_calls
+    ), "Expected 2x for --verbose, 1x for not --silent"

--- a/examples/docopt/tox.ini
+++ b/examples/docopt/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    ruff
-    py3{8,9,10,11}
+    lint
+    format
+    py3{9,10,11,12}
     requirements
     package
 
@@ -22,22 +23,22 @@ skip_install = true
 deps = pyclean
 commands = pyclean {posargs:. --debris --erase junit-report.xml --yes}
 
-[testenv:format]
-description = Ensure consistent code style
-skip_install = true
-deps = ruff
-commands = ruff format {posargs:--check --diff .}
-
-[testenv:ruff]
-description = Lightening-fast linting for Python
-skip_install = true
-deps = ruff
-commands = ruff {posargs:--show-source .}
-
 [testenv:ensure_version_matches]
 description = Verify package version is same as Git tag
 deps =
 commands = python -c 'from importlib.metadata import version; ver = version("{{package}}"); tag = "'{posargs}'"; error = f"`{ver}` != `{tag}`"; abort = f"Package version does not match the Git tag ({error}). ABORTING."; raise SystemExit(0 if ver and tag and ver == tag else abort)'
+
+[testenv:format]
+description = Ensure consistent code style (Ruff)
+skip_install = true
+deps = ruff
+commands = ruff format {posargs:--check --diff .}
+
+[testenv:lint]
+description = Lightening-fast linting (Ruff)
+skip_install = true
+deps = ruff
+commands = ruff check {posargs:--show-source .}
 
 [testenv:package]
 description = Build package and check metadata (or upload package)

--- a/examples/docopt/{{module}}/__main__.py
+++ b/examples/docopt/{{module}}/__main__.py
@@ -4,4 +4,4 @@ Helper module to run not-installed version (via ``python3 -m {{module}}``).
 from .cli import main
 
 if __name__ == "__main__":
-    main()  # pragma: no cover
+    main()

--- a/examples/docopt/{{module}}/command.py
+++ b/examples/docopt/{{module}}/command.py
@@ -8,7 +8,6 @@ def dispatch(file, silent, verbose):
     """An example implementation"""
     try:
         with Path(file).open() as textfile:
-
             if verbose:
                 print("Opening text file for reading...")
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 [tox]
 envlist =
-    ruff
+    lint
     format
     py3{7,8,9,10,11,12}
     pypy3{8,9}
@@ -41,7 +41,7 @@ skip_install = true
 deps = copier
 commands =
     copier copy {toxinidir} {toxworkdir}/examples/argparse -d engine='Argparse' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
-    tox -c {toxworkdir}/examples/argparse/tox.ini -e ruff
+    tox -c {toxworkdir}/examples/argparse/tox.ini -e lint,format
     tox -c {toxworkdir}/examples/argparse/tox.ini -e py -- -vv
 allowlist_externals =
     tox
@@ -52,7 +52,7 @@ skip_install = true
 deps = copier
 commands =
     copier copy {toxinidir} {toxworkdir}/examples/click -d engine='Click' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
-    tox -c {toxworkdir}/examples/click/tox.ini -e ruff
+    tox -c {toxworkdir}/examples/click/tox.ini -e lint,format
     tox -c {toxworkdir}/examples/click/tox.ini -e py -- -vv
 allowlist_externals =
     tox
@@ -63,16 +63,22 @@ skip_install = true
 deps = copier
 commands =
     copier copy {toxinidir} {toxworkdir}/examples/docopt -d engine='Docopt' -d package='foobar' -d module='foobar' --defaults --vcs-ref HEAD
-    tox -c {toxworkdir}/examples/docopt/tox.ini -e ruff
+    tox -c {toxworkdir}/examples/docopt/tox.ini -e lint,format
     tox -c {toxworkdir}/examples/docopt/tox.ini -e py -- -vv
 allowlist_externals =
     tox
 
 [testenv:format]
-description = Ensure consistent code style
+description = Ensure consistent code style (Ruff)
 skip_install = true
 deps = ruff
 commands = ruff format {posargs:--check --diff .}
+
+[testenv:lint]
+description = Lightening-fast linting (Ruff)
+skip_install = true
+deps = ruff
+commands = ruff check {posargs:--show-source .}
 
 [testenv:package]
 description = Build package and check metadata (or upload package)
@@ -87,9 +93,3 @@ passenv =
     TWINE_USERNAME
     TWINE_PASSWORD
     TWINE_REPOSITORY_URL
-
-[testenv:ruff]
-description = Lightening-fast linting for Python
-skip_install = true
-deps = ruff
-commands = ruff {posargs:--show-source .}


### PR DESCRIPTION
For a better developer experience, we use the name "lint" along with "format" to perform basic quality assurance.

In addition, we drop Python 3.8 as the baseline Python version for our examples.