### PR TITLE
Run test suite against Python 3.13 and PyPy 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,10 @@ jobs:
         - '3.10'
         - '3.11'
         - '3.12'
+        - '3.13'
         - pypy-3.8
         - pypy-3.9
+        - pypy-3.10
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Testing",

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@
 envlist =
     lint
     format
-    py3{8,9,10,11,12}
-    pypy3{8,9}
+    py3{8,9,10,11,12,13}
+    pypy3{8,9,10}
     package
     docs
     clean


### PR DESCRIPTION
Prepares the release of version 4.1.0, which drops support for Python 3.7 and updates some parts of the documentation.